### PR TITLE
Fixed association= method when working with relations.

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -59,7 +59,7 @@ module ActsAsTenant
       
         define_method "#{association}=" do |model|  
           if new_record?
-            write_attribute(association, model)  
+            super(model) 
           else
             raise "#{association} is immutable!"
           end  


### PR DESCRIPTION
write_attribute(attribute, model) does not work when the model is an ActiveRecord model and not an id.  Updated to use super instead.  Allows something like this: User.create(:account => Account.first)
