### PR TITLE
Fixes a bug when don't use a default tenant name.

### DIFF
--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -10,7 +10,7 @@ module ActsAsTenant
         attr_accessor :current_tenant
       end
 
-      self.tenant_class = tenant.to_s.capitalize.constantize
+      self.tenant_class = tenant.to_s.camelcase.constantize
       self.tenant_column = column.to_sym
 
       self.class_eval do


### PR DESCRIPTION
When use another model name that is not "account", example "user_account"
return "Useraccount"  when should be "UserAccount".
