### PR TITLE
Added runtime and development dependencies to gemspec

### DIFF
--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -17,4 +17,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  
+  s.add_dependency('rails','>= 3.1')
+
+  s.add_development_dependency('rspec')
+  s.add_development_dependency('database_cleaner')
+  s.add_development_dependency('sqlite3')
 end


### PR DESCRIPTION
I took a shot at adding the development and runtime dependencies for this gem. This should allow a developer to check out the project and run `bundle install` and `bundle exec rspec` to the test suite. 
