### PR TITLE
Added ActsAsTenant::with_tenant

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -6,6 +6,20 @@ module ActsAsTenant
   class << self
     cattr_accessor :tenant_class
     attr_accessor :current_tenant
+
+    # Sets the current_tenant within the given block
+    def with_tenant(tenant, &block)
+      if block.nil?
+        raise ArgumentError, "block required"
+      end
+
+      old_tenant = self.current_tenant
+      self.current_tenant = tenant
+
+      block.call
+
+      self.current_tenant= old_tenant
+    end
   end
   
   module ModelExtensions

--- a/spec/model_extensions_spec.rb
+++ b/spec/model_extensions_spec.rb
@@ -220,4 +220,31 @@ describe ActsAsTenant do
       ActsAsTenant.current_tenant = @account
       Task.create(:name => 'bar').valid?.should == true
   end
+
+  describe "::with_tenant" do
+    it "should set current_tenant to the specified tenant inside the block" do
+      @account = Account.create!(:name => 'baz')
+
+      ActsAsTenant.with_tenant(@account) do
+        ActsAsTenant.current_tenant.should eq(@account)
+      end
+    end
+
+
+    it "should return current_tenant to the previous tenant once exiting the block" do
+      @account1 = Account.create!(:name => 'foo')
+      @account2 = Account.create!(:name => 'bar')
+      
+      ActsAsTenant.current_tenant = @account1
+      ActsAsTenant.with_tenant @account2 do
+
+      end
+
+      ActsAsTenant.current_tenant.should eq(@account1)
+    end
+
+    it "should raise an error when no block is provided" do
+      expect { ActsAsTenant.with_tenant(nil) }.to raise_error(ArgumentError, /block required/)
+    end
+  end
 end


### PR DESCRIPTION
This method allows a developer to temporarily set the current tenant within the given block. It will be useful for managing the current tenant when working outside the controller, such as in a worker process. Tests are also included.
