### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -55,8 +55,9 @@ module ActsAsTenant
         # - validate that associations belong to the tenant, currently only for belongs_to
         #
         before_validation Proc.new {|m|
-          return unless ActsAsTenant.current_tenant
-          m.send "#{association}_id=".to_sym, ActsAsTenant.current_tenant.id
+          if ActsAsTenant.current_tenant
+            m.send "#{association}_id=".to_sym, ActsAsTenant.current_tenant.id
+          end
         }, :on => :create
     
         reflect_on_all_associations.each do |a|

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -61,7 +61,7 @@ end
 
 class Task < ActiveRecord::Base
   belongs_to :project
-  default_scope :conditions => { :completed => nil }, :order => "name"
+  default_scope -> { where(:completed => nil).order("name") }
 
   acts_as_tenant :account
   validates_uniqueness_of :name
@@ -115,10 +115,10 @@ describe ActsAsTenant do
       @project2 = @account2.projects.create!(:name => 'baz')
 
       ActsAsTenant.current_tenant= @account1
-      @projects = Project.unscoped.all
+      @projects = Project.unscoped
     end
 
-    it { @projects.length.should == 2 }
+    it { @projects.count.should == 2 }
   end
 
   describe 'Associations should be correctly scoped by current tenant' do
@@ -277,7 +277,7 @@ describe ActsAsTenant do
       end
       
       it "should raise an error when no tenant is provided" do
-        expect { Project.all }.to raise_error
+        expect { Project.all.load }.to raise_error(ActsAsTenant::Errors::NoTenantSet)
       end
     end
   end


### PR DESCRIPTION
Remove return from before_validation proc to fix exception under Rails 4 head. Remove Rails 4.0.0.rc1 deprecation warnings.

Now with clean Git history!
