### PR TITLE
Allow tenant to be set if it is presently nil.

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -76,13 +76,13 @@ module ActsAsTenant
         # - Add a helper method to verify if a model has been scoped by AaT
         #
         define_method "#{ActsAsTenant.fkey}=" do |integer|
-          raise ActsAsTenant::Errors::TenantIsImmutable unless new_record?
-          write_attribute("#{ActsAsTenant.fkey}", integer)  
+          raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(ActsAsTenant.fkey).nil?
+          write_attribute("#{ActsAsTenant.fkey}", integer)
         end
 
-        define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|  
-          raise ActsAsTenant::Errors::TenantIsImmutable unless new_record?
-          super(model) 
+        define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|
+          raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(ActsAsTenant.fkey).nil?
+          super(model)
         end
         
         def scoped_by_tenant?

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -165,13 +165,23 @@ describe ActsAsTenant do
     end
   end
 
-  describe 'tenant_id should be immutable' do
+  describe 'tenant_id should be immutable, if already set' do
     before do
       @account = Account.create!(:name => 'foo')
       @project = @account.projects.create!(:name => 'bar')
     end
 
     it { lambda {@project.account_id = @account.id + 1}.should raise_error }
+  end
+
+  describe 'tenant_id should be mutable, if not already set' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      @project = Project.create!(:name => 'bar')
+    end
+
+    it { @project.account_id.should be_nil }
+    it { lambda { @project.account = @account }.should_not raise_error }
   end
 
   describe 'Associations can only be made with in-scope objects' do
@@ -275,7 +285,7 @@ describe ActsAsTenant do
         @project1 = @account1.projects.create!(:name => 'foobar')
         ActsAsTenant.configuration.stub(require_tenant: true)
       end
-      
+
       it "should raise an error when no tenant is provided" do
         expect { Project.all.load }.to raise_error(ActsAsTenant::Errors::NoTenantSet)
       end


### PR DESCRIPTION
This is helpful, for instance, during a multi-step user/account registration process.

Existing tenants are still immutable, but if one has, say, a user confirmation step as part of registration process, allowing the unconfirmed user to gain a tenant once confirmed and the tenant created is really convenient.

Thanks in advance for your consideration!
