### PR TITLE
Fix scoped_by_tenant? and add new class options

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -42,7 +42,6 @@ module ActsAsTenant
 
     module ClassMethods
       def acts_as_tenant(tenant = :account, options = {})
-
         ActsAsTenant.set_tenant_klass(tenant)
 
         valid_options = options.slice(:foreign_key, :class_name)
@@ -95,8 +94,10 @@ module ActsAsTenant
           super()
         end
 
-        def scoped_by_tenant?
-          true
+        class << self
+          def scoped_by_tenant?
+            true
+          end
         end
       end
 


### PR DESCRIPTION
After first acts_as_tenant call - all active record classes will `respond_to? :scoped_by_tenant` and return true
Also you don't have class_name for a belongs_to params which needed
