### PR TITLE
Make tenant attribute immutable only if the current tenant is set.

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -81,8 +81,11 @@ module ActsAsTenant
         # - Add a helper method to verify if a model has been scoped by AaT
         #
         define_method "#{fkey}=" do |integer|
-          raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil?
-          write_attribute("#{fkey}", integer)
+          if ActsAsTenant.current_tenant.present? && integer != ActsAsTenant.current_tenant.id && !new_record?
+            raise ActsAsTenant::Errors::TenantIsImmutable
+          else
+            write_attribute("#{fkey}", integer)
+          end
         end
 
         define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -117,23 +117,50 @@ describe ActsAsTenant do
     it {UnscopedModel.respond_to?(:scoped_by_tenant?).should == false}
   end
 
-  describe 'tenant_id should be immutable, if already set' do
-    before do
-      @account = Account.create!(:name => 'foo')
-      @project = @account.projects.create!(:name => 'bar')
+  context "when current tenant is set" do
+    describe 'tenant_id should be immutable, if already set' do
+      before do
+        @account = Account.create!(:name => 'foo')
+        @project = @account.projects.create!(:name => 'bar')
+        ActsAsTenant.current_tenant = @account
+      end
+
+      it { lambda {@project.account_id = @account.id + 1}.should raise_error }
     end
 
-    it { lambda {@project.account_id = @account.id + 1}.should raise_error }
+    describe 'tenant_id should be mutable, if not already set' do
+      before do
+        @account = Account.create!(:name => 'foo')
+        @project = Project.create!(:name => 'bar')
+        ActsAsTenant.current_tenant = @account
+      end
+
+      it { @project.account_id.should be_nil }
+      it { lambda { @project.account = @account }.should_not raise_error }
+    end
   end
 
-  describe 'tenant_id should be mutable, if not already set' do
-    before do
-      @account = Account.create!(:name => 'foo')
-      @project = Project.create!(:name => 'bar')
+  context "when current tenant not set" do
+    describe 'tenant_id should be mutable, if already set' do
+      before do
+        @account = Account.create!(:name => 'foo')
+        @project = @account.projects.create!(:name => 'bar')
+        ActsAsTenant.current_tenant = nil
+      end
+
+      it { lambda {@project.account_id = @account.id + 1}.should_not raise_error }
     end
 
-    it { @project.account_id.should be_nil }
-    it { lambda { @project.account = @account }.should_not raise_error }
+    describe 'tenant_id should be mutable, if not already set' do
+      before do
+        @account = Account.create!(:name => 'foo')
+        @project = Project.create!(:name => 'bar')
+        ActsAsTenant.current_tenant = nil
+      end
+
+      it { @project.account_id.should be_nil }
+      it { lambda { @project.account = @account }.should_not raise_error }
+    end
   end
 
   describe 'Handles custom foreign_key on tenant model' do


### PR DESCRIPTION
It's need to make tenant attribute immutable only if the current tenant
is set. Sometimes a system area doesn't have a tenant set, needs to edit
that attribute. An example:

When you are in a administrative area and a tenant is not set. You need be able
to edit the tenant attribute.
