### PR TITLE
use hash syntax for default scope

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -53,7 +53,7 @@ module ActsAsTenant
           if ActsAsTenant.configuration.require_tenant && ActsAsTenant.current_tenant.nil?
             raise ActsAsTenant::Errors::NoTenantSet
           end
-          where("#{self.table_name}.#{fkey} = ?", ActsAsTenant.current_tenant.id)  if ActsAsTenant.current_tenant
+          where({"#{self.table_name}.#{fkey}" => ActsAsTenant.current_tenant.id})  if ActsAsTenant.current_tenant
         }
 
         # Add the following validations to the receiving model:

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -136,6 +136,14 @@ describe ActsAsTenant do
     it { lambda { @project.account = @account }.should_not raise_error }
   end
 
+  describe 'tenant_id should auto populate after initialization' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      ActsAsTenant.current_tenant = @account
+    end
+    it {Project.new.account_id.should == @account.id}
+  end
+
   describe 'Handles custom foreign_key on tenant model' do
     before do
       @account  = Account.create!(:name => 'foo')


### PR DESCRIPTION
Hello! We recently upgraded from version 3.1 to 3.4 and noticed that the foreign key was no longer being automatically set when initializing a new record. Example:

```
# Using acts_as_tenant 3.1
> ActsAsTenant.with_tenant(Account.find(18)) { Vehicle.new }
=> #<Vehicle id: nil, name: nil, account_id: 18, ... >
```

```
# Using acts_as_tenant 3.4
> ActsAsTenant.with_tenan4(Account.find(18)) { Vehicle.new }
=> #<Vehicle id: nil, name: nil, account_id: nil, ... >
```

I realize that the tenant_id is set during the `before_validation` block, but this causes problems for us as 
1. We sometimes need the tenant to be set immediately after initialization, and
2. We sometimes save records without validation, such as during large imports, so the tenant_id never gets set.

The commit that broke this functionality can be found [here](https://github.com/ErwinM/acts_as_tenant/commit/5eead22eff512e91e1e03e16ac729192e652d50b). The issue is that the `where` originally used hash syntax, and was later changed to binding syntax (which makes use of the `?`). By default, ActiveRecord automatically populates the values in the `where` clause found in a default scope if the hash syntax is used, but does no such thing if the `where` parameters are passed as bindings. So the solution is to revert back to the hash syntax while still specifying the table name.

I've also added a simple spec in order to test for this. Hope it is to your standards.
