### PR TITLE
Remove debugger dependency in gemspec

### DIFF
--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec-rails')
   s.add_development_dependency('database_cleaner')
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('debugger')
 
   s.add_development_dependency('sidekiq', '>= 3.0')
 end


### PR DESCRIPTION
Debugger does not run with MRI 2.1.2 and up, nor is it explicitly supported on any MRI 2.x Ruby.  You can see more details here - https://github.com/cldwalker/debugger#known-issues

Removing debugger allows the specs to run under Ruby 2.1.2.
