### PR TITLE
Fix specs that use the now removed be_true matcher

### DIFF
--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -7,7 +7,7 @@ describe ActsAsTenant::Configuration do
     end
 
     it 'provides defaults' do
-      ActsAsTenant.configuration.require_tenant.should_not be_true
+      ActsAsTenant.configuration.require_tenant.should_not be_truthy
     end
   end
 
@@ -21,7 +21,7 @@ describe ActsAsTenant::Configuration do
         config.require_tenant = true
       end
 
-      ActsAsTenant.configuration.require_tenant.should be_true
+      ActsAsTenant.configuration.require_tenant.should eq(true)
     end
 
   end

--- a/spec/acts_as_tenant/sidekiq_spec.rb
+++ b/spec/acts_as_tenant/sidekiq_spec.rb
@@ -54,7 +54,7 @@ describe ActsAsTenant::Sidekiq do
   describe 'Sidekiq configuration' do
     describe 'client configuration' do
       it 'includes ActsAsTenant client' do
-        expect(Sidekiq.client_middleware.exists?(ActsAsTenant::Sidekiq::Client)).to be_true
+        expect(Sidekiq.client_middleware.exists?(ActsAsTenant::Sidekiq::Client)).to eq(true)
       end
     end
 


### PR DESCRIPTION
The be_true matcher has been removed from RSpec 3.  The use of this matcher is causing the specs to fail on Travis or when run locally.  Fixing this issue turns the specs green.
