### PR TITLE
Update model extension.rb to fix #82

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -70,7 +70,7 @@ module ActsAsTenant
           unless a == reflect_on_association(tenant) || a.macro != :belongs_to || a.options[:polymorphic]
             association_class =  a.options[:class_name].nil? ? a.name.to_s.classify.constantize : a.options[:class_name].constantize
             validates_each a.foreign_key.to_sym do |record, attr, value|
-              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || association_class.where(:id => value).present?
+              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || association_class.where(association_class.primary_key.to_sym => value).present?
             end
           end
         end


### PR DESCRIPTION
Now, association_class query is made generic (by primary_key), not by id. Useful where primary_key has been changed for another attribute.
