### PR TITLE
add Sidekiq middleware before Sidekiq's own Retry middleware.

### DIFF
--- a/lib/acts_as_tenant/sidekiq.rb
+++ b/lib/acts_as_tenant/sidekiq.rb
@@ -38,6 +38,6 @@ Sidekiq.configure_server do |config|
     chain.add ActsAsTenant::Sidekiq::Client
   end
   config.server_middleware do |chain|
-    chain.add ActsAsTenant::Sidekiq::Server
+    chain.insert_before Sidekiq::Middleware::Server::RetryJobs, ActsAsTenant::Sidekiq::Server
   end
 end


### PR DESCRIPTION
This way, inside the sidekiq_retries_exhausted block,
the current_tenant will be properly set.

Fixes https://github.com/ErwinM/acts_as_tenant/issues/84
