### PR TITLE
Default tenant accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,21 @@ Add the following code to your `config/initializer/acts_as_tenant.rb`:
 require 'acts_as_tenant/sidekiq'
 ```
 
-Note on testing
+Testing
 ---------------
-Whenever you set the `current_tenant` in your tests, either through integration tests or directly by calling `ActsAsTenant.current_tenant = some_tenant`, make sure to clean up the tenant after each test by calling `ActsAsTenant.current_tenant = nil`.
+
+If you set the `current_tenant` in your tests, make sure to clean up the tenant after each test by calling `ActsAsTenant.current_tenant = nil`. If you are manually setting the `current_tenant` in integration tests, please be aware that the value will not survive across multiple requests, even if they take place within the same test.
+
+If you'd like to set a default tenant that will survive across multiple requests, assign a value to `default_tenant`. This can later be overridden by using any of the standard methods for specifying a different tenant. You can add a before hook with something like this to your tests:
+
+```ruby
+# Make the default tenant globally available to the tests
+$default_account = Account.create!
+# Specify this account as the current tenant unless overridden
+ActsAsTenant.default_tenant = $default_account
+# Stub out the method setting a tenant in a controller hook
+allow_any_instance_of(ApplicationController).to receive(:set_current_tenant)
+```
 
 To Do
 -----

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Testing
 
 If you set the `current_tenant` in your tests, make sure to clean up the tenant after each test by calling `ActsAsTenant.current_tenant = nil`. If you are manually setting the `current_tenant` in integration tests, please be aware that the value will not survive across multiple requests, even if they take place within the same test.
 
-If you'd like to set a default tenant that will survive across multiple requests, assign a value to `default_tenant`. This can later be overridden by using any of the standard methods for specifying a different tenant. You can add a before hook with something like this to your tests:
+If you'd like to set a default tenant that will survive across multiple requests, assign a value to `default_tenant`. You might use a before hook like this:
 
 ```ruby
 # Make the default tenant globally available to the tests
@@ -164,6 +164,8 @@ ActsAsTenant.default_tenant = $default_account
 # Stub out the method setting a tenant in a controller hook
 allow_any_instance_of(ApplicationController).to receive(:set_current_tenant)
 ```
+
+This can later be overridden by using any of the standard methods for specifying a different tenant. If you don't want this setting to apply to all of your tests, remember to clear it when you're finished by setting `ActsAsTenant.default_tenant = nil`.
 
 To Do
 -----

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -18,7 +18,11 @@ module ActsAsTenant
   end
 
   def self.current_tenant
-    RequestStore.store[:current_tenant]
+    RequestStore.store[:current_tenant] || self.default_tenant
+  end
+
+  class << self
+    attr_accessor :default_tenant
   end
 
   def self.with_tenant(tenant, &block)

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -400,4 +400,44 @@ describe ActsAsTenant do
       end
     end
   end
+
+  describe "ActsAsTenant.default_tenant=" do
+    before(:each) do
+      @account = Account.create!
+    end
+
+    it "provides current_tenant" do
+      ActsAsTenant.default_tenant = @account
+      expect(ActsAsTenant.current_tenant).to eq(@account)
+    end
+
+    it "can be overridden by assignment" do
+      ActsAsTenant.default_tenant = @account
+      @account2 = Account.create!
+      ActsAsTenant.current_tenant = @account2
+      expect(ActsAsTenant.current_tenant).not_to eq(@account)
+    end
+
+    it "can be overridden by with_tenant" do
+      ActsAsTenant.default_tenant = @account
+      @account2 = Account.create!
+      ActsAsTenant.with_tenant @account2 do
+        expect(ActsAsTenant.current_tenant).to eq(@account2)
+      end
+      expect(ActsAsTenant.current_tenant).to eq(@account)
+    end
+
+    it "doesn't override existing current_tenant" do
+      @account2 = Account.create!
+      ActsAsTenant.current_tenant = @account2
+      ActsAsTenant.default_tenant = @account
+      expect(ActsAsTenant.current_tenant).to eq(@account2)
+    end
+
+    it "survives request resets" do
+      ActsAsTenant.default_tenant = @account
+      RequestStore.clear!
+      expect(ActsAsTenant.current_tenant).to eq(@account)
+    end
+  end
 end

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -406,6 +406,10 @@ describe ActsAsTenant do
       @account = Account.create!
     end
 
+    after(:each) do
+      ActsAsTenant.default_tenant = nil
+    end
+
     it "provides current_tenant" do
       ActsAsTenant.default_tenant = @account
       expect(ActsAsTenant.current_tenant).to eq(@account)


### PR DESCRIPTION
Allows setting a default tenant on the module itself that will provide `current_tenant` in the absences of anything else. This setting will survive request cycles. I wanted this specifically for testing reasons, but gave it a generic name since it's not necessarily limited to that.

Here's how I use it in my test setup (and stub out the usual domain-based setter behavior):


```ruby
$default_tenant = Tenant.create!
ActsAsTenant.default_tenant = $default_tenant
allow_any_instance_of(ApplicationController).to receive(:set_current_tenant)
```