### PR TITLE
Add fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,18 @@ You can explicitely specifiy a foreign_key for AaT to use should the key differ 
 
 Configuration options
 ---------------------
-An initializer can be created to control (currently one) option in ActsAsTenant. Defaults
+An initializer can be created to control options in ActsAsTenant. Defaults
 are shown below with sample overrides following. In `config/initializer/acts_as_tenant.rb`:
 
 ```ruby
 ActsAsTenant.configure do |config|
   config.require_tenant = false # true
+  config.allow_fallback = false # true
 end
 ```
 
 * `config.require_tenant` when set to true will raise an ActsAsTenant::NoTenant error whenever a query is made without a tenant set.
+* `config.allow_falllback` when set to true will make it so queries return models associated with `current_tenant` and models with no tenant specified at all
 
 Sidekiq support
 ---------------

--- a/lib/acts_as_tenant/configuration.rb
+++ b/lib/acts_as_tenant/configuration.rb
@@ -16,11 +16,14 @@ module ActsAsTenant
   end
 
   class Configuration
-    attr_writer :require_tenant
-  
+    attr_writer :require_tenant, :allow_fallback
+
     def require_tenant
       @require_tenant ||= false
     end
-  
+
+    def allow_fallback
+      @allow_fallback ||= false
+    end
   end
 end

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -54,10 +54,17 @@ module ActsAsTenant
             raise ActsAsTenant::Errors::NoTenantSet
           end
           if ActsAsTenant.current_tenant
-            if ActsAsTenant.configuration.allow_fallback
-              where(fkey.to_sym => [ActsAsTenant.current_tenant.id, nil])
+            if const_defined? "Mongoid"
+              if ActsAsTenant.configuration.allow_fallback
+                self.in(fkey.to_sym => [ActsAsTenant.current_tenant.id, nil])
+              else
+                where(fkey.to_sym => ActsAsTenant.current_tenant.id)
+              end
             else
-              where(fkey.to_sym => ActsAsTenant.current_tenant.id)
+              keys = [ActsAsTenant.current_tenant.id]
+              keys.push nil if ActsAsTenant.configuration.allow_fallback
+
+              where(fkey.to_sym => keys)
             end
           else
             all

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -54,7 +54,9 @@ module ActsAsTenant
             raise ActsAsTenant::Errors::NoTenantSet
           end
           if ActsAsTenant.current_tenant
-            where(fkey.to_sym => ActsAsTenant.current_tenant.id)
+            tenant_ids = [ActsAsTenant.current_tenant.id]
+            tenant_ids.push nil if ActsAsTenant.configuration.allow_fallback
+            where(fkey.to_sym => tenant_ids)
           else
             all
           end

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -54,9 +54,11 @@ module ActsAsTenant
             raise ActsAsTenant::Errors::NoTenantSet
           end
           if ActsAsTenant.current_tenant
-            tenant_ids = [ActsAsTenant.current_tenant.id]
-            tenant_ids.push nil if ActsAsTenant.configuration.allow_fallback
-            where(fkey.to_sym => tenant_ids)
+            if ActsAsTenant.configuration.allow_fallback
+              where(fkey.to_sym => [ActsAsTenant.current_tenant.id, nil])
+            else
+              where(fkey.to_sym => ActsAsTenant.current_tenant.id)
+            end
           else
             all
           end

--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -19,9 +19,11 @@ describe ActsAsTenant::Configuration do
     it 'stores config' do
       ActsAsTenant.configure do |config|
         config.require_tenant = true
+        config.allow_fallback = true
       end
 
       expect(ActsAsTenant.configuration.require_tenant).to eq(true)
+      expect(ActsAsTenant.configuration.allow_fallback).to eq(true)
     end
 
   end

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -63,6 +63,7 @@ describe ActsAsTenant do
 
       @project1 = @account1.projects.create!(:name => 'foobar')
       @project2 = @account2.projects.create!(:name => 'baz')
+      @project3 = Project.create(:name => 'bizz')
 
       ActsAsTenant.current_tenant= @account1
       @projects = Project.all
@@ -70,6 +71,33 @@ describe ActsAsTenant do
 
     it { expect(@projects.length).to eq(1) }
     it { expect(@projects).to eq([@project1]) }
+  end
+
+  describe 'with allow_fallback set, Project.all should be scoped to the current tenant or resources with no tenant specified if current tenant is set' do
+    before do
+      ActsAsTenant.configure do |config|
+        config.allow_fallback = true
+      end
+
+      @account1 = Account.create!(:name => 'foo')
+      @account2 = Account.create!(:name => 'bar')
+
+      @project1 = @account1.projects.create!(:name => 'foobar')
+      @project2 = @account2.projects.create!(:name => 'baz')
+      @project3 = Project.create(:name => 'bizz')
+
+      ActsAsTenant.current_tenant= @account1
+      @projects = Project.all
+    end
+
+    after do
+      ActsAsTenant.configure do |config|
+        config.allow_fallback = false
+      end
+    end
+
+    it { expect(@projects.length).to eq(2) }
+    it { expect(@projects).to match_array([@project1, @project3]) }
   end
 
   describe 'Project.unscoped.all should return the unscoped value' do


### PR DESCRIPTION
When trying to use `acts_as_tenant` I found that I wanted some of my models to not be associated with a tenant so that they could be used as a fallback when the tenant is unknown.

As the gem is currently written, setting the `tenant_id` to nil on a model will make it not show up and this PR would make it so if you set `config.allow_fallback = true` then if you do something like `@tenant.models` then you'll get your tenant's associated models AND any models without tenants set.
