### PR TITLE
Arguments (including tenant_id) could be passed as strings(vs integer…

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -94,12 +94,12 @@ module ActsAsTenant
         # - Add a helper method to verify if a model has been scoped by AaT
         to_include = Module.new do
           define_method "#{fkey}=" do |integer|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer
+            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey).to_s == integer.to_s
             write_attribute("#{fkey}", integer)
           end
 
           define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer
+            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey).to_s == integer.to_s
             super(model)
           end
 

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -37,6 +37,15 @@ describe ActsAsTenant do
     it { expect { @project.account = @account }.not_to raise_error }
   end
 
+  describe 'tenant_id provided as a string should not treated as a different tenant_id if it`s the same' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      @project = @account.projects.create!(:name => 'bar')
+    end
+
+    it { expect {@project.account_id = @account.id.to_s }.not_to raise_error }
+  end
+
   describe 'tenant_id should auto populate after initialization' do
     before do
       @account = Account.create!(:name => 'foo')


### PR DESCRIPTION
…s) to the server. As result it won't recognize it as not cchanged, because db will return integer. Converting both of them to strings to fix it