### PR TITLE
Require yaml before excecuting tests.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 $orm = ENV["ORM"] || "active_record"
+require 'yaml'
 require "#{$orm}_helper"
 
 require 'rspec/rails'


### PR DESCRIPTION
Before adding the following line, I was gettting the following error while running tests

```
~/w/acts_as_tenant git:tests-fix ❯❯❯ rspec spec                                                                                                                                
/Users/sohaib/work/acts_as_tenant/spec/active_record_helper.rb:4:in `<top (required)>': uninitialized constant YAML (NameError)
        from /Users/sohaib/work/acts_as_tenant/spec/spec_helper.rb:5:in `require'
        from /Users/sohaib/work/acts_as_tenant/spec/spec_helper.rb:5:in `<top (required)>'
```

The version of Ruby being used is ruby 2.2.1. Requiring 'yaml' resolves this issue.
