### PR TITLE
Setting tenant_id to a string might be okay

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -94,13 +94,15 @@ module ActsAsTenant
         # - Add a helper method to verify if a model has been scoped by AaT
         to_include = Module.new do
           define_method "#{fkey}=" do |integer|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer.to_i
             write_attribute("#{fkey}", integer)
+            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            integer
           end
 
           define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == model
             super(model)
+            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            model
           end
 
           define_method "#{ActsAsTenant.tenant_klass.to_s}" do

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -94,12 +94,12 @@ module ActsAsTenant
         # - Add a helper method to verify if a model has been scoped by AaT
         to_include = Module.new do
           define_method "#{fkey}=" do |integer|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer
+            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer.to_i
             write_attribute("#{fkey}", integer)
           end
 
           define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|
-            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == integer
+            raise ActsAsTenant::Errors::TenantIsImmutable unless new_record? || send(fkey).nil? || send(fkey) == model
             super(model)
           end
 

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -1,5 +1,6 @@
 require 'rails/all'
 require 'database_cleaner'
+require 'yaml'
 
 dbconfig = YAML::load(IO.read(File.join(File.dirname(__FILE__), 'database.yml')))
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -27,6 +27,15 @@ describe ActsAsTenant do
     it { expect {@project.account_id = @account.id + 1}.to raise_error }
   end
 
+  describe 'setting tenant_id to the same value should not error' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      @project = @account.projects.create!(:name => 'bar')
+    end
+
+    it { expect {@project.account_id = @account.id}.not_to raise_error }
+  end
+
   describe 'tenant_id should be mutable, if not already set' do
     before do
       @account = Account.create!(:name => 'foo')

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -36,6 +36,15 @@ describe ActsAsTenant do
     it { expect {@project.account_id = @account.id}.not_to raise_error }
   end
 
+  describe 'setting tenant_id to a string with same to_i value should not error' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      @project = @account.projects.create!(:name => 'bar')
+    end
+
+    it { expect {@project.account_id = @account.id.to_s}.not_to raise_error }
+  end
+
   describe 'tenant_id should be mutable, if not already set' do
     before do
       @account = Account.create!(:name => 'foo')


### PR DESCRIPTION
In Ruby, String#to_i returns an integer if the string begins with an
integer.

    2.2.2 :001 > "1-microsoft-way".to_i
    => 1

Rails takes advantage of this behavior and does not bother converting
fields such as `tenant_id` from String to Integer types. We should allow
these values to be passed into the `"#{fkey}="` methods as well.