### PR TITLE
Allow `inverse_of` to be used in the `acts_as_tenant` declaration.

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -49,7 +49,7 @@ module ActsAsTenant
         ActsAsTenant.set_tenant_klass(tenant)
 
         # Create the association
-        valid_options = options.slice(:foreign_key, :class_name)
+        valid_options = options.slice(:foreign_key, :class_name, :inverse_of)
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
         belongs_to tenant, valid_options
 


### PR DESCRIPTION
Can be useful for ActiveRecord in preventing duplicate queries.