### PR TITLE
Ability to disable tenant verification for a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Master
 ------
 * (Sub)domain lookup is no case insensitive
 * Added ability to use inverse_of (thx lowjoel)
+* Added ability to disable tenant checking for a block (thx duboff)
 
 0.3.9
 -----

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ any code in this block will be scoped to the current tenant. All methods that se
 
 **Note:** If the current tenant is not set by one of these methods, Acts_as_tenant will be unable to apply the proper scope to your models. So make sure you use one of the two methods to tell acts_as_tenant about the current tenant.
 
+### Disabling tenant checking for a block ###
+
+```ruby
+ActsAsTenant.without_tenant do
+  # Tenant checking is disabled for all code in this block
+end
+```
+This is useful in shared routes such as admin panels or internal dashboards when `require_tenant` option is enabled throughout the app.
+
 ### Require tenant to be set always ###
 
 If you want to require the tenant to be set at all times, you can configure acts_as_tenant to raise an error when a query is made without a tenant available. See below under configuarion options.


### PR DESCRIPTION
This addresses #125 by adding an ability to run a block of code without tenant being checked even if require_tenant is set to true in the initializer.

The most common use case is having the require_tenant enabled across the app but disabling it in the admin panel or when working with data in the console.

# Usage
```rb
ActsAsTenant.without_tenant do
  Post.all
end
```