### PR TITLE
Fix Error When Validating `belong_to` Associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Master
 ------
 * (Sub)domain lookup is no case insensitive
 * Added ability to use inverse_of (thx lowjoel)
+* Allow for validation that associations belong to the tenant to reflect on
+associations which return an Array from `where` (thx ludamillion)
 
 0.3.9
 -----

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -87,7 +87,7 @@ module ActsAsTenant
                             else
                               a.primary_key
                             end.to_sym
-              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || association_class.where(primary_key => value).exists?
+              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || association_class.where(primary_key => value).any?
             end
           end
         end


### PR DESCRIPTION
When reflecting on `belongs_to` associations in the validation steps
(./lib/acts_as_tenant/model_extensions.rb:90) an undefined method error
is thrown if the `association_class` is a class that returns an Array in
response to the `#where` query.

Use `#any?` instead of `#exists?` to perform this check.

No tests added at this point since the existing tests would break if this change caused a change in behavior.