### PR TITLE
Explicitly use nil tenant in sidekiq server

### DIFF
--- a/lib/acts_as_tenant/sidekiq.rb
+++ b/lib/acts_as_tenant/sidekiq.rb
@@ -23,6 +23,8 @@ module ActsAsTenant::Sidekiq
       else
         yield
       end
+    ensure
+      RequestStore.clear!
     end
   end
 end

--- a/spec/acts_as_tenant/sidekiq_spec.rb
+++ b/spec/acts_as_tenant/sidekiq_spec.rb
@@ -49,6 +49,14 @@ describe ActsAsTenant::Sidekiq do
       end
       expect(ActsAsTenant.current_tenant).to be_nil
     end
+
+    it 'clears current_tenant after job is finished' do
+      allow(Account).to receive(:find).with(1234) { account }
+      ActsAsTenant.current_tenant = account
+      msg = message
+      subject.call(nil, msg, nil) {}
+      expect(ActsAsTenant.current_tenant).to be_nil
+    end
   end
 
   describe 'Sidekiq configuration' do


### PR DESCRIPTION
fixes #126 
sidekiq 4's worker threads are persisting tenant information from previous workers.  it's better to explicitly to wrap w/ `AAT.with_tenant(nil) { yield }` so that the sidekiq job would be run without tenant as intended.
