### PR TITLE
Fix deprecation of before_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Alternatively, you could locate the tenant using the method `set_current_tenant_
 ```ruby
 class ApplicationController < ActionController::Base
   set_current_tenant_through_filter
-  before_filter :your_method_that_finds_the_current_tenant
+  before_action :your_method_that_finds_the_current_tenant
 
   def your_method_that_finds_the_current_tenant
     current_account = Account.find_it
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Setting the `current_tenant` yourself, requires you to declare `set_current_tenant_through_filter` at the top of your application_controller to tell acts_as_tenant that you are going to use a before_filter to setup the current tenant. Next you should actually setup that before_filter to fetch the current tenant and pass it to `acts_as_tenant` by using `set_current_tenant(current_tenant)` in the before_filter.
+Setting the `current_tenant` yourself, requires you to declare `set_current_tenant_through_filter` at the top of your application_controller to tell acts_as_tenant that you are going to use a before_action to setup the current tenant. Next you should actually setup that before_action to fetch the current tenant and pass it to `acts_as_tenant` by using `set_current_tenant(current_tenant)` in the before_action.
 
 
 ### Setting the current tenant for a block ###

--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -13,7 +13,7 @@ module ActsAsTenant
       self.tenant_column = column.to_sym
 
       self.class_eval do
-        before_filter :find_tenant_by_subdomain
+        before_action :find_tenant_by_subdomain
         helper_method :current_tenant
 
         private
@@ -42,7 +42,7 @@ module ActsAsTenant
       self.tenant_second_column = second_column.to_sym
 
       self.class_eval do
-        before_filter :find_tenant_by_subdomain_or_domain
+        before_action :find_tenant_by_subdomain_or_domain
         helper_method :current_tenant
 
         private
@@ -62,7 +62,7 @@ module ActsAsTenant
 
 
     # This method sets up a method that allows manual setting of the current_tenant. This method should
-    # be used in a before_filter. In addition, a helper is setup that returns the current_tenant
+    # be used in a before_action. In addition, a helper is setup that returns the current_tenant
     def set_current_tenant_through_filter
       self.class_eval do
         helper_method :current_tenant

--- a/spec/acts_as_tenant/tenant_by_filter_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_filter_spec.rb
@@ -8,7 +8,7 @@ end
 class ApplicationController2 < ActionController::Base
   include Rails.application.routes.url_helpers
   set_current_tenant_through_filter
-  before_filter :your_method_that_finds_the_current_tenant
+  before_action :your_method_that_finds_the_current_tenant
 
   def your_method_that_finds_the_current_tenant
     current_account = Account.new


### PR DESCRIPTION
The `before_filter` macro in Rails 5 has a deprecation warning and will be removed in Rails 5.1. As an initial step I have replaced all references of `before_filter` with `before_action`. All specs passed locally for me.

I noticed the PR https://github.com/ErwinM/acts_as_tenant/pull/117 which was focused on the same fix but as master has diverged there are now more references to fix.

I realise that you may want to use `before_filter`for apps prior to Rails 4 for backwards compatibility but I'm not sure how you might want to support older versions of Rails. I'm happy to help out, but this is a quick fix for Rails 5 support.

Thanks for the great gem!

💖 
