### PR TITLE
adding the ability to have global tenant records

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -184,8 +184,18 @@ module ActsAsTenant
         if ActsAsTenant.models_with_global_records.include?(self)
           validate do |instance|
             Array(fields).each do |field|
-              unless self.class.where(fkey.to_sym => [nil, instance[fkey]], field.to_sym => instance[field]).empty?
-                errors.add(field, 'has already been taken') 
+              if instance.new_record?
+                unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
+                                        field.to_sym => instance[field]).empty?
+                  errors.add(field, 'has already been taken') 
+                end
+              else
+                unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
+                                        field.to_sym => instance[field])
+                                 .where.not(:id => instance.id).empty?
+                  errors.add(field, 'has already been taken') 
+                end
+
               end
             end
           end

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -88,7 +88,9 @@ module ActsAsTenant
             raise ActsAsTenant::Errors::NoTenantSet
           end
           if ActsAsTenant.current_tenant
-            where(fkey.to_sym => ActsAsTenant.current_tenant.id)
+            keys = [ActsAsTenant.current_tenant.id]
+            keys.push(nil) if options[:has_global_records]
+            where(fkey.to_sym => keys)
           else
             Rails::VERSION::MAJOR < 4 ? scoped : all
           end

--- a/spec/active_record_models.rb
+++ b/spec/active_record_models.rb
@@ -112,4 +112,5 @@ class GlobalProject < ActiveRecord::Base
   self.table_name = 'projects'
 
   acts_as_tenant :account, has_global_records: true
+  validates_uniqueness_to_tenant :name
 end

--- a/spec/active_record_models.rb
+++ b/spec/active_record_models.rb
@@ -107,3 +107,9 @@ class Comment < ActiveRecord::Base
   belongs_to :task, -> { where(comments: { commentable_type: 'Task'  })  }, foreign_key: 'commentable_id'
   acts_as_tenant :account
 end
+
+class GlobalProject < ActiveRecord::Base
+  self.table_name = 'projects'
+
+  acts_as_tenant :account, has_global_records: true
+end

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -135,6 +135,17 @@ describe ActsAsTenant do
     it 'should return two projects' do
       expect(GlobalProject.all.count).to eq(2)
     end
+
+    it 'should validate the project name against the global records too' do
+      expect(GlobalProject.new(:name => 'foobar').valid?).to be(false)
+      expect(GlobalProject.new(:name => 'foobar new').valid?).to be(true)
+      expect(GlobalProject.new(:name => 'foobar global').valid?).to be(false)
+    end
+
+    it 'should add the model to ActsAsTenant.models_with_global_records' do
+      expect(ActsAsTenant.models_with_global_records.include?(GlobalProject)).to be(true)
+      expect(ActsAsTenant.models_with_global_records.include?(Project)).to be(false)
+    end
   end
 
   # Associations

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -123,6 +123,20 @@ describe ActsAsTenant do
     it { @project.account }
   end
 
+  describe 'A tenant model with global records' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      @project1 = GlobalProject.create!(:name => 'foobar global')
+      @project2 = GlobalProject.create!(:name => 'unaccessible project', :account => Account.create!)
+      ActsAsTenant.current_tenant = @account
+      @project3 = GlobalProject.create!(:name => 'foobar')
+    end
+
+    it 'should return two projects' do
+      expect(GlobalProject.all.count).to eq(2)
+    end
+  end
+
   # Associations
   describe 'Associations should be correctly scoped by current tenant' do
     before do

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -140,6 +140,7 @@ describe ActsAsTenant do
       expect(GlobalProject.new(:name => 'foobar').valid?).to be(false)
       expect(GlobalProject.new(:name => 'foobar new').valid?).to be(true)
       expect(GlobalProject.new(:name => 'foobar global').valid?).to be(false)
+      expect(@project1.valid?).to be(true)
     end
 
     it 'should add the model to ActsAsTenant.models_with_global_records' do


### PR DESCRIPTION
This pull request address #149 and in my opinion is an enhance to #104 

It enables you to have global records (foreign_key equals to nil) for any `acts_as_tenant` table using the option `has_global_records` as follow:

`acts_as_tenant :account, has_global_records: true`

@ErwinM I want to know your thoughts to go ahead for improving the `validates_uniqueness_to_tenant` and also the documentation.
