### PR TITLE
Fix Rspec/Rails deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Alternatively, you could locate the tenant using the method `set_current_tenant_
 ```ruby
 class ApplicationController < ActionController::Base
   set_current_tenant_through_filter
-  before_filter :your_method_that_finds_the_current_tenant
+  before_action :your_method_that_finds_the_current_tenant
 
   def your_method_that_finds_the_current_tenant
     current_account = Account.find_it
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Setting the `current_tenant` yourself, requires you to declare `set_current_tenant_through_filter` at the top of your application_controller to tell acts_as_tenant that you are going to use a before_filter to setup the current tenant. Next you should actually setup that before_filter to fetch the current tenant and pass it to `acts_as_tenant` by using `set_current_tenant(current_tenant)` in the before_filter.
+Setting the `current_tenant` yourself, requires you to declare `set_current_tenant_through_filter` at the top of your application_controller to tell acts_as_tenant that you are going to use a before_action to setup the current tenant. Next you should actually setup that before_action to fetch the current tenant and pass it to `acts_as_tenant` by using `set_current_tenant(current_tenant)` in the before_action.
 
 
 ### Setting the current tenant for a block ###

--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rspec', '>=3.0')
   s.add_development_dependency('rspec-rails')
-  s.add_development_dependency('database_cleaner', '~> 1.3.0')
+  s.add_development_dependency('database_cleaner', '~> 1.5.3')
   s.add_development_dependency('sqlite3')
   #s.add_development_dependency('mongoid', '~> 4.0')
 

--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -13,7 +13,7 @@ module ActsAsTenant
       self.tenant_column = column.to_sym
 
       self.class_eval do
-        before_filter :find_tenant_by_subdomain
+        before_action :find_tenant_by_subdomain
         helper_method :current_tenant
 
         private
@@ -42,7 +42,7 @@ module ActsAsTenant
       self.tenant_second_column = second_column.to_sym
 
       self.class_eval do
-        before_filter :find_tenant_by_subdomain_or_domain
+        before_action :find_tenant_by_subdomain_or_domain
         helper_method :current_tenant
 
         private
@@ -62,7 +62,7 @@ module ActsAsTenant
 
 
     # This method sets up a method that allows manual setting of the current_tenant. This method should
-    # be used in a before_filter. In addition, a helper is setup that returns the current_tenant
+    # be used in a before_action. In addition, a helper is setup that returns the current_tenant
     def set_current_tenant_through_filter
       self.class_eval do
         helper_method :current_tenant

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -24,7 +24,7 @@ describe ActsAsTenant do
       @project = @account.projects.create!(:name => 'bar')
     end
 
-    it { expect {@project.account_id = @account.id + 1}.to raise_error }
+    it { expect {@project.account_id = @account.id + 1}.to raise_error(ActsAsTenant::Errors::TenantIsImmutable) }
   end
 
   describe 'setting tenant_id to the same value should not error' do

--- a/spec/acts_as_tenant/tenant_by_filter_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_filter_spec.rb
@@ -8,7 +8,7 @@ end
 class ApplicationController2 < ActionController::Base
   include Rails.application.routes.url_helpers
   set_current_tenant_through_filter
-  before_filter :your_method_that_finds_the_current_tenant
+  before_action :your_method_that_finds_the_current_tenant
 
   def your_method_that_finds_the_current_tenant
     current_account = Account.new
@@ -22,7 +22,7 @@ end
 describe ApplicationController2, :type => :controller do
   controller do
     def index
-      render :text => "custom called"
+      render :plain => "custom called"
     end
   end
 

--- a/spec/acts_as_tenant/tenant_by_subdomain_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_subdomain_spec.rb
@@ -12,7 +12,7 @@ end
 describe ApplicationController, :type => :controller do
   controller do
     def index
-      render :text => "custom called"
+      render :plain => "custom called"
     end
   end
 


### PR DESCRIPTION
The repo is throwing `before_filter`, `render text:` and a few RSpec deprecation warnings.

This PR fixes all of those, while keeping everything backwards compatible.