### PR TITLE
Make gem compatible with ActionController::API

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -18,6 +18,10 @@ if defined?(ActionController::Base)
   ActionController::Base.extend ActsAsTenant::ControllerExtensions
 end
 
+if defined?(ActionController::API)
+  ActionController::API.extend ActsAsTenant::ControllerExtensions
+end
+
 module ActsAsTenant
 end
   

--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -14,7 +14,7 @@ module ActsAsTenant
 
       self.class_eval do
         before_filter :find_tenant_by_subdomain
-        helper_method :current_tenant
+        helper_method :current_tenant if respond_to?(:helper_method)
 
         private
           def find_tenant_by_subdomain
@@ -43,7 +43,7 @@ module ActsAsTenant
 
       self.class_eval do
         before_filter :find_tenant_by_subdomain_or_domain
-        helper_method :current_tenant
+        helper_method :current_tenant if respond_to?(:helper_method)
 
         private
           def find_tenant_by_subdomain_or_domain
@@ -65,7 +65,7 @@ module ActsAsTenant
     # be used in a before_filter. In addition, a helper is setup that returns the current_tenant
     def set_current_tenant_through_filter
       self.class_eval do
-        helper_method :current_tenant
+        helper_method :current_tenant if respond_to?(:helper_method)
 
         private
           def set_current_tenant(current_tenant_object)


### PR DESCRIPTION
This PR fixes the issue #156.

This changeset makes the gem compatible with ActionController::API as it is with ActionController::Base out of the box. It makes the ActionController::API extends the controller extensions if it exists and it calls the ActionController::Base methods only if they are available.