### PR TITLE
#161 - Changed Sidekiq Middleware Insert

### DIFF
--- a/lib/acts_as_tenant/sidekiq.rb
+++ b/lib/acts_as_tenant/sidekiq.rb
@@ -38,6 +38,10 @@ Sidekiq.configure_server do |config|
     chain.add ActsAsTenant::Sidekiq::Client
   end
   config.server_middleware do |chain|
-    chain.insert_before Sidekiq::Middleware::Server::RetryJobs, ActsAsTenant::Sidekiq::Server
+    if defined?(Sidekiq::Middleware::Server::RetryJobs)
+      chain.insert_before Sidekiq::Middleware::Server::RetryJobs, ActsAsTenant::Sidekiq::Server
+    else
+      chain.add ActsAsTenant::Sidekiq::Server
+    end
   end
 end


### PR DESCRIPTION
Sidekiq removed all middleware in version `5.0`. Added a check to see if `Sidekiq::Middleware::Server::RetryJobs` is defined before attempted to insert ActsAsTenant's middleware before it. If it doesn't exist the middleware will just be added to the chain.

Not quite sure what side effects there are. I've made sure that new jobs and retried jobs are added with the ActsAsTenant information and also that records are being correctly tenanted while running the job.

Also unsure of how to handle testing. ActsAsTenant will still work correctly, it's the Sidekiq workers that will fail to start.

Open to other methods of fixing this.

Thanks!

(TravisCI fails since `before_filter` is deprecated. That's fixed in PR #145)