### PR TITLE
Replace last calls to before_filter with before_action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Replace all `before_filter` with `before_action` for Rails 5.1 compatibility
+
 0.4.1
 ------
 * Removed (stale, no longer working) MongoDB support; moved code to separate branch

--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency('request_store', '>= 1.0.5')
-  s.add_dependency('rails','>= 3.1')
+  s.add_dependency('rails','>= 4.0')
   #s.add_dependency('request_store', '>= 1.0.5')
 
   s.add_development_dependency('rspec', '>=3.0')

--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -14,7 +14,7 @@ module ActsAsTenant
 
       self.class_eval do
 
-        before_filter :find_tenant_by_subdomain
+        before_action :find_tenant_by_subdomain
         helper_method :current_tenant if respond_to?(:helper_method)
 
 
@@ -45,7 +45,7 @@ module ActsAsTenant
 
       self.class_eval do
 
-        before_filter :find_tenant_by_subdomain_or_domain
+        before_action :find_tenant_by_subdomain_or_domain
         helper_method :current_tenant if respond_to?(:helper_method)
 
 


### PR DESCRIPTION
This is necessary for Rails 5 and 5.1, as `before_filter` has been removed.

This also increases the dependency on Rails >= 4.0, as `before_action` has been introduced in that version.

I would also recommend to create a new major release of acts_as_tenant, e.g. `1.0.0`
