### PR TITLE
Allow polymorphic tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Replace all `before_filter` with `before_action` for Rails 5.1 compatibility
+
 0.4.1
 ------
 * Removed (stale, no longer working) MongoDB support; moved code to separate branch

--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency('request_store', '>= 1.0.5')
-  s.add_dependency('rails','>= 3.1')
+  s.add_dependency('rails','>= 4.0')
   #s.add_dependency('request_store', '>= 1.0.5')
 
   s.add_development_dependency('rspec', '>=3.0')

--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -14,7 +14,7 @@ module ActsAsTenant
 
       self.class_eval do
 
-        before_filter :find_tenant_by_subdomain
+        before_action :find_tenant_by_subdomain
         helper_method :current_tenant if respond_to?(:helper_method)
 
 
@@ -45,7 +45,7 @@ module ActsAsTenant
 
       self.class_eval do
 
-        before_filter :find_tenant_by_subdomain_or_domain
+        before_action :find_tenant_by_subdomain_or_domain
         helper_method :current_tenant if respond_to?(:helper_method)
 
 

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -22,6 +22,10 @@ module ActsAsTenant
     "#{@@tenant_klass.to_s}_id"
   end
 
+  def self.polymorphic_type
+    "#{@@tenant_klass.to_s}_type"
+  end
+
   def self.current_tenant=(tenant)
     RequestStore.store[:current_tenant] = tenant
   end
@@ -92,6 +96,7 @@ module ActsAsTenant
         # Create the association
         valid_options = options.slice(:foreign_key, :class_name, :inverse_of)
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
+        polymorphic_type = valid_options[:foreign_type] || ActsAsTenant.polymorphic_type
         belongs_to tenant, valid_options
 
         default_scope lambda {
@@ -101,11 +106,18 @@ module ActsAsTenant
           if ActsAsTenant.current_tenant
             keys = [ActsAsTenant.current_tenant.id]
             keys.push(nil) if options[:has_global_records]
-            where(fkey.to_sym => keys)
+
+            query_criteria = { fkey.to_sym => keys }
+            query_criteria.merge!({ polymorphic_type.to_sym => ActsAsTenant.current_tenant.class.to_s }) if options[:polymorphic]
+            where(query_criteria)
           else
             Rails::VERSION::MAJOR < 4 ? scoped : all
           end
         }
+
+        polymorphic_foreign_keys = reflect_on_all_associations(:belongs_to).select do |a|
+          a.options[:polymorphic]
+        end.map { |a| a.foreign_key }
 
         # Add the following validations to the receiving model:
         # - new instances should have the tenant set
@@ -113,13 +125,14 @@ module ActsAsTenant
         #
         before_validation Proc.new {|m|
           if ActsAsTenant.current_tenant
-            m.send "#{fkey}=".to_sym, ActsAsTenant.current_tenant.id
+            if options[:polymorphic]
+              m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send("#{fkey}").nil?
+              m.send("#{polymorphic_type}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send("#{polymorphic_type}").nil?
+            else
+              m.send "#{fkey}=".to_sym, ActsAsTenant.current_tenant.id
+            end
           end
         }, :on => :create
-
-        polymorphic_foreign_keys = reflect_on_all_associations(:belongs_to).select do |a|
-          a.options[:polymorphic]
-        end.map { |a| a.foreign_key }
 
         reflect_on_all_associations(:belongs_to).each do |a|
           unless a == reflect_on_association(tenant) || polymorphic_foreign_keys.include?(a.foreign_key)

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -115,10 +115,6 @@ module ActsAsTenant
           end
         }
 
-        polymorphic_foreign_keys = reflect_on_all_associations(:belongs_to).select do |a|
-          a.options[:polymorphic]
-        end.map { |a| a.foreign_key }
-
         # Add the following validations to the receiving model:
         # - new instances should have the tenant set
         # - validate that associations belong to the tenant, currently only for belongs_to
@@ -133,6 +129,10 @@ module ActsAsTenant
             end
           end
         }, :on => :create
+
+        polymorphic_foreign_keys = reflect_on_all_associations(:belongs_to).select do |a|
+          a.options[:polymorphic]
+        end.map { |a| a.foreign_key }
 
         reflect_on_all_associations(:belongs_to).each do |a|
           unless a == reflect_on_association(tenant) || polymorphic_foreign_keys.include?(a.foreign_key)

--- a/spec/active_record_models.rb
+++ b/spec/active_record_models.rb
@@ -49,9 +49,19 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :accountID, :integer
   end
 
+  create_table :articles, :force => true do |t|
+    t.column :title, :string
+  end
+
   create_table :comments, :force => true do |t|
     t.column :commentable_id, :integer
     t.column :commentable_type, :string
+    t.column :account_id, :integer
+  end
+
+  create_table :polymorphic_tenant_comments, :force => true do |t|
+    t.column :polymorphic_tenant_commentable_id, :integer
+    t.column :polymorphic_tenant_commentable_type, :string
     t.column :account_id, :integer
   end
 
@@ -64,6 +74,7 @@ end
 class Project < ActiveRecord::Base
   has_one :manager
   has_many :tasks
+  has_many :polymorphic_tenant_comments, as: :polymorphic_tenant_commentable
   acts_as_tenant :account
 
   validates_uniqueness_to_tenant :name
@@ -106,6 +117,16 @@ class Comment < ActiveRecord::Base
   belongs_to :commentable, polymorphic: true
   belongs_to :task, -> { where(comments: { commentable_type: 'Task'  })  }, foreign_key: 'commentable_id'
   acts_as_tenant :account
+end
+
+class Article < ActiveRecord::Base
+  has_many :polymorphic_tenant_comments, as: :polymorphic_tenant_commentable
+end
+
+class PolymorphicTenantComment < ActiveRecord::Base
+  belongs_to :polymorphic_tenant_commentable, polymorphic: true
+  belongs_to :account
+  acts_as_tenant :polymorphic_tenant_commentable, polymorphic: true
 end
 
 class GlobalProject < ActiveRecord::Base


### PR DESCRIPTION
ActsAsTenant is unable to handle a polymorphic relationship with tenant class. Is assumes that a system is comprised of only one kind of account. This patch will enable the tenant to be one of several possible kinds of accounts. For this feature to work, this PR adds the `polymorphic: true` option to the `acts_as_tenant` declaration.

An example of where I ran into this case was an Address model. Address contains records that are shared between Supplier and Dealer under a polymorphic relationship. The system is tenanted so that a user logged in will see information relevant to either a given Supplier or Dealer (hence, two kinds of users and two different views of the system). The Address model has a `tenantable_id` and `tenantable_type` to denote which Supplier and Dealer it belongs to. This feature would not work in ActsAsTenant without the modifications of this pull request. 