### PR TITLE
fix polymorphic tenant

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -136,8 +136,8 @@ module ActsAsTenant
         before_validation Proc.new {|m|
           if ActsAsTenant.current_tenant
             if options[:polymorphic]
-              m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send("#{fkey}").nil?
-              m.send("#{polymorphic_type}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send("#{polymorphic_type}").nil?
+              m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.id)
+              m.send("#{polymorphic_type}=".to_sym, ActsAsTenant.current_tenant.class.to_s)
             else
               m.send "#{fkey}=".to_sym, ActsAsTenant.current_tenant.id
             end
@@ -214,13 +214,13 @@ module ActsAsTenant
               if instance.new_record?
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field]).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
               else
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field])
                                  .where.not(:id => instance.id).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
 
               end

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -227,14 +227,16 @@ describe ActsAsTenant do
         before do
           @comment.save!
           @article = Article.create!(id: @project.id, title: 'article title')
-          @comment_on_article = @article.polymorphic_tenant_comments.create!
+          ActsAsTenant.with_tenant(@article) do
+            @comment_on_article = @article.polymorphic_tenant_comments.create!
+          end
         end
 
         it 'correctly scopes to the current tenant type' do
           expect(@comment_on_article).to be_persisted
           expect(@comment).to be_persisted
           expect(PolymorphicTenantComment.count).to eql(1)
-          expect(PolymorphicTenantComment.all.first.attributes).to eql(@comment.attributes)
+          expect(PolymorphicTenantComment.first.attributes).to eql(@comment.attributes)
         end
       end
 


### PR DESCRIPTION
This PR fixes an issue with polymorphic tenants where the polymorphic tenant id would not be set correctly.

1. In the `before_validation` callback defined in `lib/acts_as_tenant/model_extensions.rb:136`, the original implementation of this gem (before polymorphic tenant was introduced in #169) would set the tenant id to the current tenant id. For polymorphic tenants, a similar assignment would only take place if the fields `#{fkey}` and `#{polymorphic_type}` are `nil`, which is not consistent with the previous implementation. This PR removes the `if` conditionals.

2. In the same callback on line `139` there is a bug:
```
m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.class.to_s)
```
should read 
```
m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.id)
```
This is fixed in this PR.

3. Test in `spec/acts_as_tenant/model_extensions_spec.rb:226` creates two models under the same tenant (`@project`), and yet expects only one model in the scope of the current tenant. The reason that test is (in my opinion) a false positive is because of the way the second model is created (through an association on `@article`) and the `if` conditionals mentioned above. To solve this problem, this PR wraps creating the second model in an `ActsAsTenant.with_tenant(@article)` block.


----------------------

A few additional comments:

- `if` conditionals mentioned above, and the test that passes because of them, basically allow you to keep a cached instance of an `Article` scoped to tenant A, switch to tenant B, and save a new `PolymorphicTenantComment` scoped to tenant A while tenant B is active. It seems to me that this defeats the whole purpose of this gem, please correct me if I'm wrong.

- You might wonder why the bug mentioned above never manifested itself. It's because the assignments in the `before_validation` callback are never executed, since the `#{fkey}` and `#{polymorphic_type}` are already present (they come from `default_scope` that gets executed as soon as you do `.new` on an ActiveRecord), and there's those `if` conditionals that would not override them if they're set.