### PR TITLE
Fix using acts_as_tenant without Rails

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -125,7 +125,7 @@ module ActsAsTenant
             query_criteria.merge!({ polymorphic_type.to_sym => ActsAsTenant.current_tenant.class.to_s }) if options[:polymorphic]
             where(query_criteria)
           else
-            Rails::VERSION::MAJOR < 4 ? scoped : all
+            ActiveRecord::VERSION::MAJOR < 4 ? scoped : all
           end
         }
 


### PR DESCRIPTION
Using acts_as_tenant in a project using only ActiveRecord instead of rails fails when a default or current tenant is not set due to the `Rails::VERSION::MAJOR` check.  Check the `ActiveRecord::VERSION::MAJOR` instead.

ref https://github.com/ManageIQ/topological_inventory-core/pull/76