### PR TITLE
Added pkey as configuration option

### DIFF
--- a/lib/acts_as_tenant/configuration.rb
+++ b/lib/acts_as_tenant/configuration.rb
@@ -16,10 +16,14 @@ module ActsAsTenant
   end
 
   class Configuration
-    attr_writer :require_tenant
+    attr_writer :require_tenant, :pkey
   
     def require_tenant
       @require_tenant ||= false
+    end
+    
+    def pkey
+      @pkey ||= :id
     end
   
   end

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -23,7 +23,7 @@ module ActsAsTenant
   end
 
   def self.pkey
-    :id
+    ActsAsTenant.configuration.pkey
   end
 
   def self.polymorphic_type


### PR DESCRIPTION
With good work in [this](https://github.com/ErwinM/acts_as_tenant/pull/194) pull request, we have the option of having a custom primary key.

This pull request makes pkey a configuration option.

So, below can be done -
 
```
ActsAsTenant.configure do |config|
  config.pkey = :type
end
```