### PR TITLE
Improve integration testing using optional accessor and middleware

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -35,7 +35,7 @@ module ActsAsTenant
   end
 
   def self.current_tenant
-    RequestStore.store[:current_tenant] || self.default_tenant
+    RequestStore.store[:current_tenant] || test_tenant || default_tenant
   end
 
   def self.unscoped=(unscoped)
@@ -51,6 +51,8 @@ module ActsAsTenant
   end
 
   class << self
+    attr_accessor :test_tenant
+
     def default_tenant=(tenant)
       @default_tenant = tenant
     end
@@ -212,13 +214,13 @@ module ActsAsTenant
               if instance.new_record?
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field]).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
               else
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field])
                                  .where.not(:id => instance.id).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
 
               end

--- a/lib/acts_as_tenant/test_tenant_middleware.rb
+++ b/lib/acts_as_tenant/test_tenant_middleware.rb
@@ -1,0 +1,15 @@
+module ActsAsTenant
+  class TestTenantMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      previously_set_test_tenant = ActsAsTenant.test_tenant
+      ActsAsTenant.test_tenant = nil
+      @app.call(env)
+    ensure
+      ActsAsTenant.test_tenant = previously_set_test_tenant
+    end
+  end
+end

--- a/spec/acts_as_tenant/test_tenant_middleware_spec.rb
+++ b/spec/acts_as_tenant/test_tenant_middleware_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'acts_as_tenant/test_tenant_middleware'
+require 'active_record_models'
+
+describe ActsAsTenant::TestTenantMiddleware do
+  after { ActsAsTenant.current_tenant = nil }
+  subject { request.get('/some/path') }
+
+  let(:middleware) { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+
+  let!(:account1) { Account.create }
+  let!(:account2) { Account.create }
+
+  class TestRackApp1
+    def call(_env)
+      ActsAsTenant.current_tenant = Account.first
+      TestReceiver.assert_current_id(ActsAsTenant.current_tenant.id)
+      ActsAsTenant.current_tenant = nil
+      [200, {}, ['OK']]
+    end
+  end
+
+  class TestRackApp2
+    def call(_env)
+      TestReceiver.assert_current_id(ActsAsTenant.current_tenant.try(:id))
+      [200, {}, ['OK']]
+    end
+  end
+
+  class TestReceiver
+    def self.assert_current_id(id); end
+  end
+
+  context 'when test_tenant is nil before processing' do
+    before { ActsAsTenant.test_tenant = nil }
+
+    context 'that switches tenancies' do
+      let(:app) { TestRackApp1.new }
+
+      it 'should remain nil after processing' do
+        expect(ActsAsTenant.current_tenant).to be_nil
+        expect(TestReceiver).to receive(:assert_current_id).with(account1.id)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to be_nil
+      end
+    end
+
+    context 'that does not switch tenancies' do
+      let(:app) { TestRackApp2.new }
+
+      it 'should remain nil after processing' do
+        expect(ActsAsTenant.current_tenant).to be_nil
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to be_nil
+      end
+    end
+  end
+
+  context 'when test_tenant is assigned before processing' do
+    before { ActsAsTenant.test_tenant = account2 }
+
+    context 'that switches tenancies' do
+      let(:app) { TestRackApp1.new }
+
+      it 'should remain assigned after processing' do
+        expect(ActsAsTenant.current_tenant).to eq account2
+        expect(TestReceiver).to receive(:assert_current_id).with(account1.id)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to eq account2
+      end
+    end
+
+    context 'that does not switch tenancies' do
+      let(:app) { TestRackApp2.new }
+
+      it 'should remain assigned after processing' do
+        expect(ActsAsTenant.current_tenant).to eq account2
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to eq account2
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Problem**
Integration testing with this gem can be improved. The README suggests using before-and-after hooks with `current_tenant` and `default_tenant` to have a tenancy persist through the request-response cycle. While this works, it has two big drawbacks:
- The setting of `current_tenant` bleeds into the request handling. If your tests use a "default account" (as suggested by the README), your controllers are already in a tenancy before your logic begins. This frustrates any test coverage as to whether your controllers are switching into the correct tenancy.
- Using `default_tenant` for test setup can conflict or otherwise interfere with the request processing of those apps that might utilize `default_tenant`.

The alternative -- manually switch into tenancies for every test -- is painful:
```ruby
it 'does something' do
  ActsAsTenant.with_tenant($default_account) do
    Blog.create!(title: 'foo', body: bar)
  end
  delete '/blogs/1'
 ActsAsTenant.with_tenant($default_account) do
    expect(Blog.count).to eq 0
  end
end
```

**This solution**
This adds a new `test_tenant` accessor that serves as the first fallback value (before `default_tenant`) to `current_tenant`. Additionally, there is middleware which, if `require`d and added in the test environment config, serves to clear and reset the `test_tenant` during a request/response cycle. I've added documentation that explains how it should be used.

This does add some optional complexity in setting up the gem, but I think the resulting confidence in integration testing is worth it.