### PR TITLE
allow changing tenant on models using new without_tenant! block

### DIFF
--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -394,6 +394,39 @@ describe ActsAsTenant do
     end
   end
 
+  describe "::without_tenant!" do
+    it "should return the value of the block" do
+      value = ActsAsTenant.without_tenant! do
+        "something"
+      end
+      expect(value).to eq "something"
+    end
+
+    it "should raise an error when no block is provided" do
+      expect { ActsAsTenant.without_tenant! }.to raise_error(ArgumentError, /block required/)
+    end
+
+    it "should set tenant back to immutable after the block" do
+      ActsAsTenant.without_tenant! do
+        "something"
+      end
+      expect(ActsAsTenant.mutable_tenant?).to eq false
+    end
+
+    describe 'mutability' do
+      before do
+        @account = Account.create!(:name => 'foo')
+        @project = @account.projects.create!(:name => 'bar')
+      end
+
+      it "should allow tenant_id to change inside the block" do
+        new_account_id = @account.id + 1
+        expect{ ActsAsTenant.without_tenant! { @project.account_id = new_account_id } }.to_not raise_error(ActsAsTenant::Errors::TenantIsImmutable)
+        expect(@project.account_id).to eq new_account_id
+      end
+    end
+  end
+
   # Tenant required
   context "tenant required" do
     before do


### PR DESCRIPTION
Allows changing the tenant_id column on a model if using a new `without_tenant!` block (destructive version of the existing `without_tenant`)

Related to #202 

I had a need for this when building some admin screens in our app, where it's ok to allow certain users to change the tenant on existing models in specific cases.

