### PR TITLE
Use on_load hooks to enhance rails classes (don't break other gems enhancing rails classes)

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -10,18 +10,13 @@ require "acts_as_tenant/model_extensions"
 
 #$LOAD_PATH.shift
 
-if defined?(ActiveRecord::Base)
-  ActiveRecord::Base.send(:include, ActsAsTenant::ModelExtensions)
+ActiveSupport.on_load(:active_record) do |base|
+  base.include ActsAsTenant::ModelExtensions
 end
 
-if defined?(ActionController::Base)
-  ActionController::Base.extend ActsAsTenant::ControllerExtensions
-end
-
-if defined?(ActionController::API)
-  ActionController::API.extend ActsAsTenant::ControllerExtensions
+ActiveSupport.on_load(:action_controller) do |base|
+  base.extend ActsAsTenant::ControllerExtensions
 end
 
 module ActsAsTenant
 end
-  


### PR DESCRIPTION
Fixes an issue where jbuilder on_load hooks are never run because acts_as_tenant loads the classes too early.
Fixes #201 (already closed as "workaround provided")

Similar solution as #197

I wasn't sure how to test this so I did the following:
1) rails new --api some_api_app
2) modified the Gemfile, adding jbuilder
3) bundled
4) verified "Test jbuilder" below works
5) Add acts_as_tenant to Gemfile, bundled
6) Verify "Test acts_as_tenant" works
7) See that "Test jbuilder" now fails
8) Apply this commit change.  Verify both step 6 and 7 now pass.

Test jbuilder: (verify the extensions on rails classes are done correctly)
```
require_relative "config/environment"  # Or you can skip this step if you run the below in rails console of a new rails app that
puts "testing jbuilder"
puts "ApplicationController.ancestors.include?(ActionView::Rendering): #{ApplicationController.ancestors.include?(ActionView::Rendering)}"
puts "ApplicationController::API.ancestors.include?(ActionView::Rendering): #{ApplicationController.ancestors.include?(ActionView::Rendering)}"
```

Test acts_as_tenant:  (verify the modle/controller extensions are done correctly)

```
require_relative "config/environment"  # Or you can skip this step if you run the below in rails console of a new rails app that
puts "ActiveRecord::Base.ancestors.include?(ActsAsTenant::ModelExtensions): #{ActiveRecord::Base.ancestors.include?(ActsAsTenant::ModelExtensions)}"
puts "ApplicationController.singleton_class.instance_methods.include?(:set_current_tenant_by_subdomain): #{ApplicationController.singleton_class.instance_methods.include?(:set_current_tenant_by_subdomain)}"
puts "ApplicationController::API.singleton_class.instance_methods.include?(:set_current_tenant_by_subdomain): #{ApplicationController.singleton_class.instance_methods.include?(:set_current_tenant_by_subdomain)}"
```