### PR TITLE
Remove unused variable

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -198,7 +198,6 @@ module ActsAsTenant
       def validates_uniqueness_to_tenant(fields, args ={})
         raise ActsAsTenant::Errors::ModelNotScopedByTenant unless respond_to?(:scoped_by_tenant?)
         fkey = reflect_on_association(ActsAsTenant.tenant_klass).foreign_key
-        pkey = reflect_on_association(ActsAsTenant.tenant_klass).active_record_primary_key
         #tenant_id = lambda { "#{ActsAsTenant.fkey}"}.call
         if args[:scope]
           args[:scope] = Array(args[:scope]) << fkey


### PR DESCRIPTION
https://github.com/ErwinM/acts_as_tenant/issues/211

1. This variable appears to be unused
2. This requires a db-connection to use. For my use-case, we have initializers that instantiate a few things before there is a db-connection, so this caused a regression. 

I'd love to understand why this needs to be here if it's used.