### PR TITLE
Prepare for Ruby2.7 (coping with breaking changes in the future version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: ruby
 before_install:
   - gem update bundler
 script: bundle exec rake spec
+rvm:
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - ruby-2.7.0-preview3

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -110,7 +110,7 @@ module ActsAsTenant
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
         pkey = valid_options[:primary_key] || ActsAsTenant.pkey
         polymorphic_type = valid_options[:foreign_type] || ActsAsTenant.polymorphic_type
-        belongs_to tenant, valid_options
+        belongs_to tenant, **valid_options
 
         default_scope lambda {
           if ActsAsTenant.configuration.require_tenant && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?


### PR DESCRIPTION
Hi, thank you very much for your awesome gem!

## purpose of this PR

I just happened to notice the warnings when running tests with my application (that is build upon ActsAsTenant) on Ruby2.7-rc2, possibly the closest version of Ruby for upcoming Ruby2.7.

This is mainly due to a breaking change introduced for Ruby2.7 and afterwards.
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

As it is discussed in its [original issue](https://bugs.ruby-lang.org/issues/14183) in great details, it might cause some corner case  problems, but for this gem it can be fixed with very simple code that clarifies keyword arguments as keyword arguments (not a hash object).

The purpose of this PR is to remove future errors, so that this great gem keeps working.
Specifically this patch introduces a small fix on it, as well as (as side-effects) adding tests with latest ruby versions (piked up latest patch versions from Ruby 2.4 upto Ruby 2.7)

## how it should work

Keyword arguments will be treated differently from hash objects. Assuming `delegated_method` will take keyword arguments, e.g:
```ruby
def delegated_method(foo:, bar:, baz:)
  # ...snip
end
```

The caller has to pass keyword arguments, not a hash objects.

```ruby
def some_method(opts={})
  delegated_method opts # works with Ruby2.6, will break > Ruby2.7
end
```

```ruby
def some_method(opts={})
  delegated_method **opts # works with >= Ruby2.7, as well as current Rubies.
end
```

## what this patch does

As found in travis logs, running test suites with Ruby2.7.0-preview3 would emit several warnings (basically from the same line).

Here are the logs collected from my forked repo:
```
/home/travis/build/fursich/acts_as_tenant/lib/acts_as_tenant/model_extensions.rb:113: warning: The last argument is used as the keyword parameter
/home/travis/.rvm/gems/ruby-2.7.0-preview3/gems/activerecord-6.0.2.1/lib/active_record/associations.rb:1657: warning: for `belongs_to' defined here
```

We can confirm from travis that these warnings will dissappear with the patch.

I can see other warnings but apparently they are from dependent gems (including much from Rails, where the maintainers are working on fixing them).
Hope that makes sense!