### PR TITLE
Switch from #update_attributes to #update

### DIFF
--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -195,7 +195,7 @@ describe ActsAsTenant do
       @task = @project2.tasks.create!(:name => 'bar')
     end
 
-    it { expect(@task.update_attributes(:project_id => @project1.id)).to eq(false) }
+    it { expect(@task.update(:project_id => @project1.id)).to eq(false) }
   end
 
   describe "Create and save an AaT-enabled child without it having a parent" do


### PR DESCRIPTION
Same functionality, just a newer method name.  Cleans up Rails 6 deprecation warning in tests:
```
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from block (3 levels) in <top (required)> at ..../acts_as_tenant/spec/acts_as_tenant/model_extensions_spec.rb:198)
```