### PR TITLE
Add 'counter_cache' to association options

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -106,7 +106,7 @@ module ActsAsTenant
         ActsAsTenant.add_global_record_model(self) if options[:has_global_records]
 
         # Create the association
-        valid_options = options.slice(:foreign_key, :class_name, :inverse_of, :optional, :primary_key)
+        valid_options = options.slice(:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache)
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
         pkey = valid_options[:primary_key] || ActsAsTenant.pkey
         polymorphic_type = valid_options[:foreign_type] || ActsAsTenant.polymorphic_type

--- a/spec/active_record_models.rb
+++ b/spec/active_record_models.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :name, :string
     t.column :subdomain, :string
     t.column :domain, :string
+    t.column :projects_count, :integer, :default => 0
   end
 
   create_table :projects, :force => true do |t|
@@ -117,6 +118,11 @@ class CustomPrimaryKeyTask < ActiveRecord::Base
   self.table_name = 'projects'
   acts_as_tenant(:account, :foreign_key => "name", :primary_key => "name")
   validates_presence_of :name
+end
+
+class CustomCounterCacheTask < ActiveRecord::Base
+  self.table_name = 'projects'
+  acts_as_tenant(:account, :counter_cache => 'projects_count')
 end
 
 class Comment < ActiveRecord::Base

--- a/spec/acts_as_tenant/model_extensions_spec.rb
+++ b/spec/acts_as_tenant/model_extensions_spec.rb
@@ -85,6 +85,20 @@ describe ActsAsTenant do
     it { expect(CustomPrimaryKeyTask.count).to eq(1) }
   end
 
+  describe 'Handles counter_cache on tenant model' do
+    before do
+      @account = Account.create!(:name => 'foo')
+      ActsAsTenant.current_tenant = @account
+      @project = CustomCounterCacheTask.create!(:name => 'bar')
+    end
+
+    it 'should correctly increment and decrement the tenants column' do
+      expect(@account.reload.projects_count).to eq(1)
+      @project.destroy
+      expect(@account.reload.projects_count).to eq(0)
+    end
+  end
+
   # Scoping models
   describe 'Project.all should be scoped to the current tenant if set' do
     before do


### PR DESCRIPTION
Since Rails supports the `counter_cache` option in the belongs_to association, it would be nice to add this as a feature when using the `acts_as_tenant` method in your model.

Example:

```rb
acts_as_tenant(:account, counter_cache: true)
```