### PR TITLE
Ensure middleware runs before Sidekiq::Batch::Server middleware

### DIFF
--- a/lib/acts_as_tenant/sidekiq.rb
+++ b/lib/acts_as_tenant/sidekiq.rb
@@ -40,6 +40,8 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     if defined?(Sidekiq::Middleware::Server::RetryJobs)
       chain.insert_before Sidekiq::Middleware::Server::RetryJobs, ActsAsTenant::Sidekiq::Server
+    elsif defined?(Sidekiq::Batch::Server)
+      chain.insert_before Sidekiq::Batch::Server, ActsAsTenant::Sidekiq::Server
     else
       chain.add ActsAsTenant::Sidekiq::Server
     end


### PR DESCRIPTION
Fixes https://github.com/ErwinM/acts_as_tenant/issues/203

**Context**
The [Batches API](https://github.com/mperham/sidekiq/wiki/Batches) in Sidekiq Pro allows you to create workflows where certain jobs get triggered after a set (aka a batch) of jobs finish running. It essentially works by inserting a middleware which will trigger a job (`Sidekiq::Batch::Callback`) that calls callbacks, which in turn trigger additional jobs. 

**Problem**
Currently, the `ActsAsTenant::Sidekiq::Server` middleware is added to the end of the middleware chain, which ends up being after `Sidekiq::Batch::Server`. When jobs are then enqueued from the batch middleware, they don't have `acts_as_tenant` set as part of their payload. The result is the first job in a batch will run with a tenant (if it's enqueued from a context where a tenant is set), but all subsequent jobs will run without a tenant.

**Solution**
This PR checks to see if `Sidekiq::Batch::Server` is defined, if it is, we can assume it's part of the middleware chain and add `ActsAsTenant::Sidekiq::Server` before it. This ensure that each subsequent job enqueue has an `acts_as_tenant` key set in their payload.