### PR TITLE
Fix autoload warnings on rails 6

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,2 +1,4 @@
-ActiveRecord::Base.send(:include, ActsAsTenant::ModelExtensions)
+ActiveSupport.on_load(:active_record_base) do
+  ActiveRecord::Base.send(:include, ActsAsTenant::ModelExtensions)
+end
 ActionController::Base.extend ActsAsTenant::ControllerExtensions


### PR DESCRIPTION
Calling ActiveRecord::Base.send(:include) regardless of if it has already been loaded causes autoload deprecation warnings on rails 6

```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <top (required)> at /home/agrare/src/grare/grare-monitor/monitor-api/config/environment.rb:5)
```

Fixes https://github.com/ErwinM/acts_as_tenant/issues/229