### PR TITLE
Improve GitHub Actions Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Cache gems
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{ matrix.ruby }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           sudo apt-get install libsqlite3-dev
           gem update --system
           gem install bundler
+          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bundle exec appraisal install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.ruby }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-${{ matrix.ruby }}-gem-
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
This PR improves the way gems are cached in the GitHub Actions Workflow:

* Use new version of `actions/cache@v2`
* Specifies the bundle path `vendor/bundle`, which is required by the [cache action](https://github.com/actions/cache/blob/main/examples.md#ruby---bundler)
* Creates a cache keys based on ruby version. 
  This should help with installing dependencies with native extensions. However, I don't know if this step is actually necessary, but still I consider this a good practice.