### PR TITLE
Refactor validates_uniqueness_to_tenant

### DIFF
--- a/spec/dummy/app/models/global_project_with_conditions.rb
+++ b/spec/dummy/app/models/global_project_with_conditions.rb
@@ -1,0 +1,6 @@
+class GlobalProjectWithConditions < ActiveRecord::Base
+  self.table_name = "projects"
+
+  acts_as_tenant :account, has_global_records: true
+  validates_uniqueness_to_tenant :name, conditions: -> { where(name: "foo") }
+end

--- a/spec/dummy/app/models/global_project_with_if.rb
+++ b/spec/dummy/app/models/global_project_with_if.rb
@@ -1,0 +1,6 @@
+class GlobalProjectWithIf < ActiveRecord::Base
+  self.table_name = "projects"
+
+  acts_as_tenant :account, has_global_records: true
+  validates_uniqueness_to_tenant :name, if: ->(instance) { instance.name == "foo" }
+end

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -122,7 +122,7 @@ describe ActsAsTenant do
         expect(GlobalProject.new(name: "foo new").valid?).to be(true)
       end
 
-      it "is invalid with with duplicate tenant records" do
+      it "is invalid with duplicate tenant records" do
         expect(GlobalProject.new(name: "global foo").valid?).to be(false)
       end
 


### PR DESCRIPTION
Hi,
I refactored this validation method because it didn't work for global records with [mobility](https://github.com/shioyama/mobility). Queries used in `validates_uniqueness_to_tenant` didn't work with mobility's fields.
But mobility overrides UniquenessValidator to validate translated fields.

I decided to use `validates_uniqueness_of ` in the case of global model, because `validates_uniqueness_of` runs same query by itself.

For global records:
- In 1st validates_uniqueness_of we're validating uniqueness in tenant (query: tenant = value)
- in 2nd validates_uniqueness_of we're validating global uniqueness (query: tenant = nil)

in perfect world it should be done with 1 query validating `tenant = nil OR value`, but rails validations don't allow it.