### PR TITLE
Refactor model extensions to use klass instead of constantize

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -53,14 +53,13 @@ module ActsAsTenant
 
         reflect_on_all_associations(:belongs_to).each do |a|
           unless a == reflect_on_association(tenant) || polymorphic_foreign_keys.include?(a.foreign_key)
-            association_class = a.options[:class_name].nil? ? a.name.to_s.classify.constantize : a.options[:class_name].constantize
             validates_each a.foreign_key.to_sym do |record, attr, value|
               primary_key = if a.respond_to?(:active_record_primary_key)
                 a.active_record_primary_key
               else
                 a.primary_key
               end.to_sym
-              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || association_class.where(primary_key => value).any?
+              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || a.klass.where(primary_key => value).any?
             end
           end
         end


### PR DESCRIPTION
This PR is a small refactor to use a built-in Rails method instead of using `constantize`.

The `acts_as_tenant` method used `constantize` on the association name to infer class names. This is fine for most Rails apps, but breaks down in engines with isolated namespaces. Instead, the `reflect_on_all_associations(:belongs_to)` method already returns an array of `AssociationReflection`, which has a method `klass` that returns the target association's class. 

There are two other instances of `constantize` in this gem:
- `set_current_tenant_by_subdomain`
- `set_current_tenant_by_subdomain_or_domain`

The default tenant is `:account`, which is constantized as `Account`. I thought about using `const_get` instead, but I think in this case it's better to explicitly use the namespaced version of the class you want to use as a tenant. For example:
`set_current_tenant_by_subdomain_or_domain "spina/account", :subdomain, :domain`

Sidenote: I think @excid3's last commits fixed specs of this gem.