### PR TITLE
Update logic to incorporate changes in ActiveModel::Dirty in Rails 5.2

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -82,7 +82,7 @@ module ActsAsTenant
           end
 
           define_method "tenant_modified?" do
-            (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
+            send("will_save_change_to_#{fkey}?") && persisted? && !send("#{fkey}_in_database").nil?
           end
         }
         include to_include

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -71,13 +71,13 @@ module ActsAsTenant
         to_include = Module.new {
           define_method "#{fkey}=" do |integer|
             write_attribute(fkey.to_s, integer)
-            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            raise ActsAsTenant::Errors::TenantIsImmutable if (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
             integer
           end
 
           define_method "#{ActsAsTenant.tenant_klass}=" do |model|
             super(model)
-            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            raise ActsAsTenant::Errors::TenantIsImmutable if (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
             model
           end
         }

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -82,7 +82,7 @@ module ActsAsTenant
           end
 
           define_method "tenant_modified?" do
-            send("will_save_change_to_#{fkey}?") && persisted? && !send("#{fkey}_in_database").nil?
+            will_save_change_to_attribute?(fkey) && persisted? && attribute_in_database(fkey).present?
           end
         }
         include to_include

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -71,14 +71,18 @@ module ActsAsTenant
         to_include = Module.new {
           define_method "#{fkey}=" do |integer|
             write_attribute(fkey.to_s, integer)
-            raise ActsAsTenant::Errors::TenantIsImmutable if (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
+            raise ActsAsTenant::Errors::TenantIsImmutable if tenant_modified?
             integer
           end
 
           define_method "#{ActsAsTenant.tenant_klass}=" do |model|
             super(model)
-            raise ActsAsTenant::Errors::TenantIsImmutable if (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
+            raise ActsAsTenant::Errors::TenantIsImmutable if tenant_modified?
             model
+          end
+
+          define_method "tenant_modified?" do
+            (send("will_save_change_to_#{fkey}?") || send("saved_change_to_#{fkey}?")) && persisted? && !(send("#{fkey}_in_database").nil? || send("#{fkey}_before_last_save").nil?)
           end
         }
         include to_include

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -31,6 +31,12 @@ describe ActsAsTenant do
     expect { project.account_id = account.id.to_s }.not_to raise_error
   end
 
+  it "setting tenant_id to nil should throw error" do
+    project = account.projects.create!(name: "bar")
+    expect(project.account_id).not_to be_nil
+    expect { project.account_id = nil }.to raise_error(ActsAsTenant::Errors::TenantIsImmutable)
+  end
+
   it "tenant_id should be mutable, if not already set" do
     project = projects(:without_account)
     expect(project.account_id).to be_nil


### PR DESCRIPTION
In Rails 5, Activemode::Dirty behaviour has changed for `_changed?`, `_was` in before callbacks.
For reference: https://github.com/rails/rails/pull/25337