### PR TITLE
Allow lambda for `require_tenant`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Row-level multitenancy  each model must have a tenant ID column on it. This make
 
 Schema multitenancy uses database schemas to handle multitenancy. For this approach, your database has multiple schemas and each schema contains your database tables. Schemas require migrations to be run against each tenant and generally makes it harder to scale as you add more tenants. The Apartment gem uses schema multitenancy.
 
-#### 🎬 Walkthrough 
+#### 🎬 Walkthrough
 
 Want to see how it works? Check out [the ActsAsTenant walkthrough video](https://www.youtube.com/watch?v=BIyxM9f8Jus):
 
@@ -223,9 +223,19 @@ end
 
 * `config.require_tenant` when set to true will raise an ActsAsTenant::NoTenant error whenever a query is made without a tenant set.
 
+`config.require_tenant` can also be assigned a lambda that is evaluated at run time. For example:
+
+```ruby
+ActsAsTenant.configure do |config|
+  config.require_tenant = lambda { !current_user.admin? }
+end
+```
+
+`ActsAsTenant.should_require_tenant?` is used to determine if a tenant is required in the current context, either by evaluating the lambda provided, or by returning the boolean value assigned to `config.require_tenant`.
+
 belongs_to options
 ---------------------
-`acts_as_tenant :account` includes the belongs_to relationship. 
+`acts_as_tenant :account` includes the belongs_to relationship.
 So when using acts_as_tenant on a model, do not add `belongs_to :account` alongside `acts_as_tenant :account`:
 
 ```ruby

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -112,9 +112,9 @@ module ActsAsTenant
 
   def self.should_require_tenant?
     if configuration.require_tenant.respond_to?(:call)
-      ActsAsTenant.configuration.require_tenant.call
+      configuration.require_tenant.call
     else
-      !!ActsAsTenant.configuration.require_tenant
+      !!configuration.require_tenant
     end
   end
 end

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -111,7 +111,7 @@ module ActsAsTenant
   end
 
   def self.should_require_tenant?
-    if ActsAsTenant.configuration.require_tenant.respond_to?(:call)
+    if configuration.require_tenant.respond_to?(:call)
       ActsAsTenant.configuration.require_tenant.call
     else
       !!ActsAsTenant.configuration.require_tenant

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -109,6 +109,14 @@ module ActsAsTenant
     self.current_tenant = old_tenant
     self.unscoped = old_unscoped
   end
+
+  def self.should_require_tenant?
+    if ActsAsTenant.configuration.require_tenant.respond_to?(:call)
+      ActsAsTenant.configuration.require_tenant.call
+    else
+      !!ActsAsTenant.configuration.require_tenant
+    end
+  end
 end
 
 ActiveSupport.on_load(:active_record) do |base|

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -112,7 +112,7 @@ module ActsAsTenant
 
   def self.should_require_tenant?
     if configuration.require_tenant.respond_to?(:call)
-      configuration.require_tenant.call
+      !!configuration.require_tenant.call
     else
       !!configuration.require_tenant
     end

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -16,7 +16,7 @@ module ActsAsTenant
         belongs_to tenant, **valid_options
 
         default_scope lambda {
-          if ActsAsTenant.configuration.require_tenant && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+          if ActsAsTenant.should_require_tenant? && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
             raise ActsAsTenant::Errors::NoTenantSet
           end
 

--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -14,4 +14,50 @@ describe ActsAsTenant::Configuration do
 
     expect(ActsAsTenant.configuration.require_tenant).to eq(true)
   end
+
+  describe "#should_require_tenant?" do
+    it "evaluates lambda" do
+      ActsAsTenant.configure do |config|
+        config.require_tenant = lambda { true }
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(true)
+
+      ActsAsTenant.configure do |config|
+        config.require_tenant = lambda { false }
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(false)
+    end
+
+    it "evaluates boolean" do
+      ActsAsTenant.configure do |config|
+        config.require_tenant = true
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(true)
+
+      ActsAsTenant.configure do |config|
+        config.require_tenant = false
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(false)
+    end
+
+    it "evaluates truthy" do
+      ActsAsTenant.configure do |config|
+        config.require_tenant = "foobar"
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(true)
+    end
+
+    it "evaluates falsy" do
+      ActsAsTenant.configure do |config|
+        config.require_tenant = nil
+      end
+
+      expect(ActsAsTenant.should_require_tenant?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This feature offers extra flexibility by determining if a tenant should be enforced based on additional context.