### PR TITLE
Fix test_tenant leaking into current_tenant

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -85,7 +85,7 @@ module ActsAsTenant
       raise ArgumentError, "block required"
     end
 
-    old_tenant = current_tenant
+    old_tenant = RequestStore[:current_tenant]
     self.current_tenant = tenant
     value = block.call
     value
@@ -98,7 +98,7 @@ module ActsAsTenant
       raise ArgumentError, "block required"
     end
 
-    old_tenant = current_tenant
+    old_tenant = RequestStore[:current_tenant]
     old_unscoped = unscoped
 
     self.current_tenant = nil

--- a/spec/middlewares/test_tenant_middleware_spec.rb
+++ b/spec/middlewares/test_tenant_middleware_spec.rb
@@ -81,6 +81,18 @@ describe ActsAsTenant::TestTenantMiddleware do
         expect(subject.status).to eq 200
         expect(ActsAsTenant.current_tenant).to eq account2
       end
+
+      it "does not leak test_tenant into current_tenant when using with_tenant before request" do
+        ActsAsTenant.with_tenant(account1) {}
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+      end
+
+      it "does not leak test_tenant into current_tenant when using without_tenant before request" do
+        ActsAsTenant.without_tenant {}
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+      end
     end
   end
 end


### PR DESCRIPTION
Using `test_tenant` in conjunction with `with_tenant {}` and `without_tenant {}` in some cases leads to `test_tenant` being assign to `current_tenant` which leads to subtle bugs, that are difficult to pin down.

This happens because the value of `test_tenant` is restored as `current_tenant` in the `ensure` part of those methods. The test cases in this pr illustrate the issue.