### PR TITLE
Make test_tenant implementation specific to thread

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -14,7 +14,6 @@ module ActsAsTenant
   @@models_with_global_records = []
 
   class << self
-    attr_accessor :test_tenant
     attr_writer :default_tenant
   end
 
@@ -62,6 +61,14 @@ module ActsAsTenant
 
   def self.current_tenant
     RequestStore.store[:current_tenant] || test_tenant || default_tenant
+  end
+
+  def self.test_tenant=(tenant)
+    Thread.current[:test_tenant] = tenant
+  end
+
+  def self.test_tenant
+    Thread.current[:test_tenant]
   end
 
   def self.unscoped=(unscoped)


### PR DESCRIPTION
At the moment test_tenant causes problems for system tests which run the
server and the test in separate threads. By using Thread.current we get
different test_tenant per thread.

This should also enable parrallel tests in threads.

```ruby
ActsAsTenant.test_tenant = Tenant.first
# during the visit (which is async), test_tenant is set to nil by the middleware
visit foo_url
# this following line will run in the test thread while the request is running in the other thread,
# and ActsAsTenant.current_tenant will unexpectedly be nil
SomeRecord.first
sleep 2
# once the request has finished, ActsAsTenant.current_tenant will be back to the expected
# value of Tenant.first.
SomeRecord.first
```