### PR TITLE
Honor the scope passed to associations when performing validations

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -3,7 +3,7 @@ module ActsAsTenant
     extend ActiveSupport::Concern
 
     class_methods do
-      def acts_as_tenant(tenant = :account, **options)
+      def acts_as_tenant(tenant = :account, scope = nil, **options)
         ActsAsTenant.set_tenant_klass(tenant)
         ActsAsTenant.mutable_tenant!(false)
 
@@ -14,7 +14,7 @@ module ActsAsTenant
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
         pkey = valid_options[:primary_key] || ActsAsTenant.pkey
         polymorphic_type = valid_options[:foreign_type] || ActsAsTenant.polymorphic_type
-        belongs_to tenant, **valid_options
+        belongs_to tenant, scope, **valid_options
 
         default_scope lambda {
           if ActsAsTenant.should_require_tenant? && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
@@ -66,7 +66,8 @@ module ActsAsTenant
               else
                 a.primary_key
               end.to_sym
-              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || a.klass.where(primary_key => value).any?
+              scope = a.scope || ->(relation) { relation }
+              record.errors.add attr, "association is invalid [ActsAsTenant]" unless value.nil? || a.klass.class_eval(&scope).where(primary_key => value).any?
             end
           end
         end

--- a/lib/acts_as_tenant/sidekiq.rb
+++ b/lib/acts_as_tenant/sidekiq.rb
@@ -28,7 +28,7 @@ module ActsAsTenant::Sidekiq
 
     def call(worker_class, msg, queue)
       if msg.has_key?("acts_as_tenant")
-        account = msg["acts_as_tenant"]["class"].constantize.find msg["acts_as_tenant"]["id"]
+        account = msg["acts_as_tenant"]["class"].constantize.unscoped.find msg["acts_as_tenant"]["id"]
         ActsAsTenant.with_tenant account do
           yield
         end

--- a/spec/acts_as_tenant/sidekiq_spec.rb
+++ b/spec/acts_as_tenant/sidekiq_spec.rb
@@ -29,24 +29,37 @@ describe ActsAsTenant::Sidekiq do
   describe ActsAsTenant::Sidekiq::Server do
     subject { ActsAsTenant::Sidekiq::Server.new }
 
-    it "restores tenant if tenant saved" do
-      expect(Account).to receive(:find).with(1234).once { account }
+    context "when tenant exist" do
+      before { account.save }
 
-      msg = message
-      subject.call(nil, msg, nil) do
-        expect(ActsAsTenant.current_tenant).to be_a_kind_of Account
-      end
-      expect(ActsAsTenant.current_tenant).to be_nil
-    end
-
-    it "runs without tenant if no tenant saved" do
-      expect(Account).not_to receive(:find)
-
-      msg = {}
-      subject.call(nil, msg, nil) do
+      it "restores tenant" do
+        msg = message
+        subject.call(nil, msg, nil) do
+          expect(ActsAsTenant.current_tenant).to be_a_kind_of Account
+        end
         expect(ActsAsTenant.current_tenant).to be_nil
       end
-      expect(ActsAsTenant.current_tenant).to be_nil
+
+      context "but it is outside its own scope" do
+        before { account.update!(deleted_at: Time.now) }
+
+        it "ignores the scope and sets the tenant" do
+          msg = {}
+          subject.call(nil, message, nil) do
+            expect(ActsAsTenant.current_tenant).to eq(account)
+          end
+        end
+      end
+    end
+
+    context "when tenant does not exist" do
+      it "runs without tenant" do
+        msg = {}
+        subject.call(nil, msg, nil) do
+          expect(ActsAsTenant.current_tenant).to be_nil
+        end
+        expect(ActsAsTenant.current_tenant).to be_nil
+      end
     end
   end
 

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -3,4 +3,6 @@ class Account < ActiveRecord::Base
   has_many :global_projects
   has_many :users_accounts
   has_many :users, through: :users_accounts
+
+  default_scope -> { where(deleted_at: nil) }
 end

--- a/spec/dummy/app/models/manager.rb
+++ b/spec/dummy/app/models/manager.rb
@@ -1,4 +1,4 @@
 class Manager < ActiveRecord::Base
-  belongs_to :project
-  acts_as_tenant :account
+  belongs_to :project, -> { unscope(where: :deleted_at) }
+  acts_as_tenant :account, -> { unscope(where: :deleted_at) }
 end

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -5,4 +5,6 @@ class Project < ActiveRecord::Base
   acts_as_tenant :account
 
   validates_uniqueness_to_tenant :name
+
+  default_scope -> { where(deleted_at: nil) }
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
     t.column :subdomain, :string
     t.column :domain, :string
+    t.column :deleted_at, :timestamp
     t.column :projects_count, :integer, default: 0
   end
 
@@ -22,6 +23,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
     t.column :account_id, :integer
     t.column :user_defined_scope, :string
+    t.column :deleted_at, :timestamp
   end
 
   create_table :managers, force: true do |t|

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -242,6 +242,21 @@ describe ActsAsTenant do
     expect(AliasedTask.create(name: "foo", project_alias: @project2).valid?).to eq(true)
   end
 
+  it "uses the scope passed to acts_as_tenant" do
+    account.update!(deleted_at: Time.now)
+    manager = Manager.create!(account_id: account.id)
+
+    expect(manager.valid?).to eq(true)
+    expect(manager.account).to eq(account)
+  end
+
+  it "uses the scope passed to belongs_to when validating" do
+    project = account.projects.create!(name: "foobar", deleted_at: Time.now)
+    manager = Manager.new(account: account, project: project)
+
+    expect(manager.valid?).to eq(true)
+  end
+
   describe "It should be possible to use associations with foreign_key from polymorphic" do
     it "tenanted objects have a polymorphic association" do
       ActsAsTenant.current_tenant = account


### PR DESCRIPTION
Hi @ErwinM, thanks for the awesome gem!

We recently started to migrate our whole app to use `acts_as_tenant` and found a small issue for our use case where validations performed by `acts_as_tenant` are failing when checking for the existence of `belongs_to` associations.
We have been using https://github.com/rubysherpas/paranoia for a long time (we have plans to migrate away from it in the future but it's not an easy task).
So the issue is the default scope generated by `paranoia` which makes deleted records to be skipped during validation, that makes sense since those are deleted! but in some scenarios we do want our models to access deleted associations, the way to do that is to pass a scope to the association:
```
belongs_to :other, -> { with_deleted }
```
right now `acts_as_tenant` is ignoring that scope so the validation fails.

The PR will use the scope if given.

An extra addition (that I can move to another PR if you like) is allowing to pass a scope to `act_as_tenant` and just pass the scope directly to `belongs_to` (it seems that's the only modification needed for that to work)
