### PR TITLE
Set test tenant to nil in ActsAsTenant.without_tenant block

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -14,7 +14,6 @@ module ActsAsTenant
   @@models_with_global_records = []
 
   class << self
-    attr_accessor :test_tenant
     attr_writer :default_tenant
   end
 
@@ -62,6 +61,14 @@ module ActsAsTenant
 
   def self.current_tenant
     RequestStore.store[:current_tenant] || test_tenant || default_tenant
+  end
+
+  def self.test_tenant=(tenant)
+    Thread.current[:test_tenant] = tenant
+  end
+
+  def self.test_tenant
+    Thread.current[:test_tenant]
   end
 
   def self.unscoped=(unscoped)

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -106,14 +106,17 @@ module ActsAsTenant
     end
 
     old_tenant = current_tenant
+    old_test_tenant = test_tenant
     old_unscoped = unscoped
 
     self.current_tenant = nil
+    self.test_tenant = nil
     self.unscoped = true
     value = block.call
     value
   ensure
     self.current_tenant = old_tenant
+    self.test_tenant = old_test_tenant
     self.unscoped = old_unscoped
   end
 

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -32,14 +32,14 @@ module ActsAsTenant
             if options[:through]
               query_criteria = {options[:through] => {fkey.to_sym => keys}}
               query_criteria[polymorphic_type.to_sym] = ActsAsTenant.current_tenant.class.to_s if options[:polymorphic]
-              where(query_criteria)
-                .then do |query|
+              joins(options[:through])
+                .where(query_criteria)
+                .ids
+                .then do |ids|
                   if options[:unscoped]
-                    query
-                      .or(where(options[:unscoped]))
-                      .left_joins(options[:through])
+                    where(id: ids).or(where(options[:unscoped]))
                   else
-                    query.joins(options[:through])
+                    where(id: ids)
                   end
                 end
             else

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -58,7 +58,7 @@ module ActsAsTenant
         }.map { |a| a.foreign_key }
 
         reflect_on_all_associations(:belongs_to).each do |a|
-          unless a == reflect_on_association(tenant) || polymorphic_foreign_keys.include?(a.foreign_key)
+          unless a == reflect_on_association(tenant) || polymorphic_foreign_keys.include?(a.foreign_key) || !a.klass.try(:scoped_by_tenant?)
             validates_each a.foreign_key.to_sym do |record, attr, value|
               primary_key = if a.respond_to?(:active_record_primary_key)
                 a.active_record_primary_key


### PR DESCRIPTION
When `without_tenant` was being used, it was staying connected to `test_tenant` if `test_tenant` was set. These changes reset the `test_tenant` in the same way that `current_tenant` is handled.