### PR TITLE
Set test tenant to nil in ActsAsTenant.without_tenant block

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -106,14 +106,17 @@ module ActsAsTenant
     end
 
     old_tenant = current_tenant
+    old_test_tenant = test_tenant
     old_unscoped = unscoped
 
     self.current_tenant = nil
+    self.test_tenant = nil
     self.unscoped = true
     value = block.call
     value
   ensure
     self.current_tenant = old_tenant
+    self.test_tenant = old_test_tenant
     self.unscoped = old_unscoped
   end
 

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -366,6 +366,29 @@ describe ActsAsTenant do
       expect(ActsAsTenant.current_tenant).to eq(account)
     end
 
+    it "should set test_tenant to nil inside the block" do
+      ActsAsTenant.test_tenant = account
+      ActsAsTenant.without_tenant do
+        expect(ActsAsTenant.test_tenant).to be_nil
+      end
+    end
+
+    it "should set test_tenant to nil even if default_tenant is set" do
+      old_default_tenant = ActsAsTenant.default_tenant
+      ActsAsTenant.default_tenant = Account.create!(name: "foo")
+      ActsAsTenant.without_tenant do
+        expect(ActsAsTenant.test_tenant).to be_nil
+      end
+    ensure
+      ActsAsTenant.default_tenant = old_default_tenant
+    end
+
+    it "should reset test_tenant to the previous tenant once exiting the block" do
+      ActsAsTenant.test_tenant = account
+      ActsAsTenant.without_tenant {}
+      expect(ActsAsTenant.test_tenant).to eq(account)
+    end
+
     it "should return the value of the block" do
       value = ActsAsTenant.without_tenant { "something" }
       expect(value).to eq "something"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "rspec/rails"
 RSpec.configure do |config|
   config.after(:each) do
     ActsAsTenant.current_tenant = nil
+    ActsAsTenant.test_tenant = nil
   end
 
   config.fixture_path = "spec/fixtures"


### PR DESCRIPTION
When without_tenant was being used, it was staying connected to test_tenant if test_tenant was set. These changes reset the test_tenant in the same way that current_tenant is handled.