### PR TITLE
allow 'touch' option to be passed through to belongs_to association

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ end
 ```
 
 You can add the following `belongs_to` options to `acts_as_tenant`:
-`:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache`
+`:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache, :polymorphic, :touch`
 
 Example: `acts_as_tenant(:account, counter_cache: true)`
 

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -10,7 +10,7 @@ module ActsAsTenant
         ActsAsTenant.add_global_record_model(self) if options[:has_global_records]
 
         # Create the association
-        valid_options = options.slice(:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache, :polymorphic)
+        valid_options = options.slice(:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache, :polymorphic, :touch)
         fkey = valid_options[:foreign_key] || ActsAsTenant.fkey
         pkey = valid_options[:primary_key] || ActsAsTenant.pkey
         polymorphic_type = valid_options[:foreign_type] || ActsAsTenant.polymorphic_type


### PR DESCRIPTION
Hi there! Just a small change to allow e.g. `touch: true` to be passed through to the `belongs_to` association. I also updated the readme to include `:polymorphic`, which was missing, as well as `:touch`.