### PR TITLE
Support has_many :through relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ end
 
 class User < ActiveRecord::Base
   has_many :organisations_users
-  acts_as_tenant :organisation, through: :organisations_users
+  acts_as_tenant :organisations, through: :organisations_users
 end
 
 class OrganisationsUser < ActiveRecord::Base

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -45,7 +45,7 @@ module ActsAsTenant
   end
 
   def self.fkey
-    "#{@@tenant_klass}_id"
+    "#{@@tenant_klass.to_s.singularize}_id"
   end
 
   def self.pkey

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -3,4 +3,7 @@ class Account < ActiveRecord::Base
   has_many :global_projects
   has_many :users_accounts
   has_many :users, through: :users_accounts
+
+  has_many :org_users_accounts, class_name: "UsersAccount"
+  has_many :org_users, class_name: "User", through: :org_users_accounts
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   has_many :users_accounts
-  has_many :accounts, through: :users_accounts
+  acts_as_tenant :accounts, through: :users_accounts
 
-  acts_as_tenant :account, through: :users_accounts
+  has_many :org_users_accounts, class_name: "UsersAccount", inverse_of: :org_user
+  acts_as_tenant :organizations, through: :org_users_accounts, source: :org_account, class_name: "Account", foreign_key: :account_id
 end

--- a/spec/dummy/app/models/users_account.rb
+++ b/spec/dummy/app/models/users_account.rb
@@ -1,4 +1,7 @@
 class UsersAccount < ActiveRecord::Base
   acts_as_tenant :account
   belongs_to :user
+
+  acts_as_tenant :org_account, class_name: "Account", foreign_key: :account_id
+  belongs_to :org_user, class_name: "User", foreign_key: :user_id
 end

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -121,6 +121,11 @@ describe ActsAsTenant do
       ActsAsTenant.current_tenant = account
       expect(User.unscoped.count).to be > account.users.count
     end
+
+    it "allows users to be created for the current tenant" do
+      ActsAsTenant.current_tenant = account
+      expect(User.create).to be_present
+    end
   end
 
   describe "A tenant model with global records" do


### PR DESCRIPTION
Fixes #283

While previous commits have stated that they support HABTM relationships, acts_as_tenant attempts to set the foreign_key on the record rather than in an association.

This was proven by the new spec in `spec/models/model_extensions_spec.rb` which fails with the error:
> can't write unknown attribute `account_id`

This PR makes acts_as_tenant aware that these relationships require a new record to be created on the association (unless one already exists).

## BREAKING CHANGE
Given an assumption is being made that singular tenant/association names are belongs_to and plural names are has_many, acts_as_tenant will no longer attempt to create a new association if one already exists. This will allow those with non-standard associations to manually define the relationship