### PR TITLE
Disable legacy_connection_handling

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -15,5 +15,9 @@ module Dummy
     if Rails.gem_version < Gem::Version.new("6.0") && config.active_record.sqlite3
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
+
+    if Rails.gem_version >= Gem::Version.new("6.1")
+      config.active_record.legacy_connection_handling = false
+    end
   end
 end


### PR DESCRIPTION
legacy_connection_handling has been deprecated and causes warnings when running RSpec