### PR TITLE
Replace RequestStore dependency with CurrentAttributes

### DIFF
--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "request_store", ">= 1.0.5"
   spec.add_dependency "rails", ">= 5.2"
 
   spec.add_development_dependency "rspec", ">=3.0"

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -1,5 +1,4 @@
-require "request_store"
-
+require "active_support/current_attributes"
 require "acts_as_tenant/version"
 require "acts_as_tenant/errors"
 
@@ -13,6 +12,10 @@ module ActsAsTenant
   @@tenant_klass = nil
   @@models_with_global_records = []
   @@mutable_tenant = false
+
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :current_tenant, :test_tenant, :acts_as_tenant_unscoped
+  end
 
   class << self
     attr_writer :default_tenant
@@ -57,11 +60,11 @@ module ActsAsTenant
   end
 
   def self.current_tenant=(tenant)
-    RequestStore.store[:current_tenant] = tenant
+    Current.current_tenant = tenant
   end
 
   def self.current_tenant
-    RequestStore.store[:current_tenant] || test_tenant || default_tenant
+    Current.current_tenant || test_tenant || default_tenant
   end
 
   def self.test_tenant=(tenant)
@@ -73,11 +76,11 @@ module ActsAsTenant
   end
 
   def self.unscoped=(unscoped)
-    RequestStore.store[:acts_as_tenant_unscoped] = unscoped
+    Current.acts_as_tenant_unscoped = unscoped
   end
 
   def self.unscoped
-    RequestStore.store[:acts_as_tenant_unscoped]
+    Current.acts_as_tenant_unscoped
   end
 
   def self.unscoped?

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -489,11 +489,5 @@ describe ActsAsTenant do
       ActsAsTenant.default_tenant = account
       expect(ActsAsTenant.current_tenant).to eq(accounts(:bar))
     end
-
-    it "survives request resets" do
-      ActsAsTenant.default_tenant = account
-      RequestStore.clear!
-      expect(ActsAsTenant.current_tenant).to eq(account)
-    end
   end
 end


### PR DESCRIPTION
This simplifies ActsAsTenant by dropping the RequestStore dependency. We can use Rails' built-in CurrentAttributes feature that accomplishes the same thing.

This should be a drop-in replacement, but may want to make it a major release in case there are any unknown side effects.

The only minor gripe I know of is that CurrentAttributes doesn't play well with the web-console gem because those requests are not in the same thread.