### PR TITLE
Update README.md with small dev console QoL suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,31 @@ end
 
 `ActsAsTenant.should_require_tenant?` is used to determine if a tenant is required in the current context, either by evaluating the lambda provided, or by returning the boolean value assigned to `config.require_tenant`.
 
+When using `config.require_tenant` alongside the `rails console`, a nice quality of life tweak is to set the tenant in the console session in your initializer script. For example in `config/initializers/acts_as_tenant.rb`:
+
+```ruby
+SET_TENANT_PROC = lambda do
+  if defined?(Rails::Console)
+    puts "> ActsAsTenant.current_tenant = Account.first"
+    ActsAsTenant.current_tenant = Account.first
+  end
+end
+
+Rails.application.configure do
+  if Rails.env.development?
+    # Set the tenant to the first account in development on load
+    config.after_initialize do
+      SET_TENANT_PROC.call
+    end
+
+    # Reset the tenant after calling 'reload!' in the console
+    ActiveSupport::Reloader.to_complete do
+      SET_TENANT_PROC.call
+    end
+  end
+end
+```
+
 belongs_to options
 ------------------
 


### PR DESCRIPTION
Adds a section on having your rails console automatically set the current tenant on load/reload while in development. I know this has saved our team a lot of time by reducing some dev friction.