### PR TITLE
Add additional pkeys to scope if given

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -24,6 +24,9 @@ module ActsAsTenant
           if ActsAsTenant.current_tenant
             keys = [ActsAsTenant.current_tenant.send(pkey)].compact
             keys.push(nil) if options[:has_global_records]
+            if options[:additional_pkeys_method]
+              keys.push(*ActsAsTenant.current_tenant.send(options[:additional_pkeys_method]))
+            end
 
             if options[:through]
               query_criteria = {options[:through] => {fkey.to_sym => keys}}


### PR DESCRIPTION
This allows for the user, when setting up `acts_as_tenant` for a model, to specify an option for a method that the tenant responds to that will give additional pkeys for including in the default scope of the data.

This allows for data from multiple tenants to be read in a tenant (without changing behavior of writing data). It works much in the same way that `has_global_records` does, but rather than global records, allows for other tenants' data to be included.