### PR TITLE
Serialize tenant to string instead of GlobalID

### DIFF
--- a/lib/acts_as_tenant/active_job_extensions.rb
+++ b/lib/acts_as_tenant/active_job_extensions.rb
@@ -1,7 +1,7 @@
 module ActsAsTenant
   module ActiveJobExtensions
     def serialize
-      super.merge("current_tenant" => ActsAsTenant.current_tenant&.to_global_id)
+      super.merge("current_tenant" => ActsAsTenant.current_tenant&.to_global_id&.to_s)
     end
 
     def deserialize(job_data)


### PR DESCRIPTION
PROBLEM:
Upgrading to acts_as_tenant 1.0 started raising this error:
```
ArgumentError: Job arguments to Turbo::Streams::ActionBroadcastJob must be native JSON types, but #<GlobalID:0x000000010f555540 @uri=#<URI::GID gid://equipped/Account/1>> is a GlobalID. (ArgumentError)
See https://github.com/sidekiq/sidekiq/wiki/Best-Practices
To disable this error, add `Sidekiq.strict_args!(false)` to your initializer.


            raise(ArgumentError, msg)
```

POSSIBLE CAUSE:
6ecf5d2d2e74338362142f5a52464a65ee6dae7c introduced the breaking change.

SUGGESTED FIX:
Sidekiq best practices prefer JSON types and GlobalID::Locator.locate works with the string representation of GlobalID (which is a unique URI). This keeps the desired change of commit 6ecf5d2d2e74338362142f5a52464a65ee6dae7c, but is more compatible with Sidekiq (and requires less serialization overhead)

The fix is included in this PR.
