### PR TITLE
Add `global_records_identifier` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ ActsAsTenant.configure do |config|
 end
 ```
 
+* Add `config.global_records_identifier` configuration. [#332](https://github.com/ErwinM/acts_as_tenant/pull/332)
+
+This is helpful when you want to use a different global records identifier instead of `nil`:
+
+```ruby
+ActsAsTenant.configure do |config|
+  config.global_records_identifier = 1
+end
+```
+
 1.0.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ are shown below with sample overrides following. In `config/initializers/acts_as
 ```ruby
 ActsAsTenant.configure do |config|
   config.require_tenant = false # true
+  config.global_records_identifier = nil
 
   # Customize the query for loading the tenant in background jobs
   config.job_scope = ->{ all }

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -58,6 +58,10 @@ module ActsAsTenant
     @@models_with_global_records.push(model)
   end
 
+  def self.global_records_identifier
+    ActsAsTenant.configuration.global_records_identifier
+  end
+
   def self.fkey
     "#{@@tenant_klass}_id"
   end

--- a/lib/acts_as_tenant/configuration.rb
+++ b/lib/acts_as_tenant/configuration.rb
@@ -1,6 +1,6 @@
 module ActsAsTenant
   class Configuration
-    attr_writer :require_tenant, :pkey
+    attr_writer :require_tenant, :pkey, :global_records_identifier
     attr_reader :tenant_change_hook
 
     def require_tenant
@@ -9,6 +9,10 @@ module ActsAsTenant
 
     def pkey
       @pkey ||= :id
+    end
+
+    def global_records_identifier
+      @global_records_identifier ||= nil
     end
 
     def job_scope

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -23,7 +23,7 @@ module ActsAsTenant
 
           if ActsAsTenant.current_tenant
             keys = [ActsAsTenant.current_tenant.send(pkey)].compact
-            keys.push(nil) if options[:has_global_records]
+            keys.push(ActsAsTenant.global_records_identifier) if options[:has_global_records]
 
             if options[:through]
               query_criteria = {options[:through] => {fkey.to_sym => keys}}


### PR DESCRIPTION
we have a model using global records feature in `acts_as_tenant` gem

```
class Member < ApplicationRecord
  acts_as_tenant(:organization, has_global_records: true)
end
``` 

With a given tenant scope `1`, It generates SQL like below:
```
SELECT `members`.* FROM `members` WHERE (`members`.`organization_id` = 1 OR `members`.`organization_id` IS NULL)
```

as the data increased, it spent about 2s, but after we changed the global records identifier to  a number `3`, the query time decreased to 70ms.

```
SELECT `members`.* FROM `members` WHERE `members`.`organization_id` IN (1, 3)
```
It looks like MySQL doesn't perform well on `NULL`values index.
So I proposed this pull request to make the global records identifier configurable.

```ruby
ActsAsTenant.configure do |config|
  config.global_records_identifier = 3
end
```

```
Development [1] demo(main)> ActsAsTenant.global_records_identifier
3
Development [2] demo(main)> Member.all.to_sql
"SELECT `members`.* FROM `members`"
Development [3] demo(main)> ActsAsTenant.with_tenant(Organization.first) { Member.all.to_sql }
"SELECT `members`.* FROM `members` WHERE `members`.`organization_id` IN (1, 3)"
Development [4] demo(main)> ActsAsTenant.with_tenant(Organization.last) { Member.all.to_sql }
"SELECT `members`.* FROM `members` WHERE `members`.`organization_id` IN (2, 3)"
```


It doesn't change the default behaviour, hope it is acceptable. 
Any feedback is welcome.
Thanks.


