### PR TITLE
Add a tenant change hook

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -18,13 +18,13 @@ module ActsAsTenant
     attribute :current_tenant, :acts_as_tenant_unscoped
 
     def current_tenant=(tenant)
-      r = super
-      configuration.tenant_change_hook.call(tenant) if configuration.tenant_change_hook.present?
-      r
+      super.tap do
+        configuration.tenant_change_hook.call(tenant) if configuration.tenant_change_hook.present?
+      end
     end
 
     def configuration
-      Module.nesting.last.class_variable_get("@@configuration")
+      Module.nesting.last.class_variable_get(:@@configuration)
     end
   end
 

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -16,6 +16,16 @@ module ActsAsTenant
 
   class Current < ActiveSupport::CurrentAttributes
     attribute :current_tenant, :acts_as_tenant_unscoped
+
+    def current_tenant=(tenant)
+      r = super
+      configuration.tenant_change_hook.call(tenant) if configuration.tenant_change_hook.present?
+      r
+    end
+
+    def configuration
+      Module.nesting.last.class_variable_get("@@configuration")
+    end
   end
 
   class << self

--- a/lib/acts_as_tenant/configuration.rb
+++ b/lib/acts_as_tenant/configuration.rb
@@ -1,6 +1,7 @@
 module ActsAsTenant
   class Configuration
     attr_writer :require_tenant, :pkey
+    attr_reader :tenant_change_hook
 
     def require_tenant
       @require_tenant ||= false
@@ -27,5 +28,11 @@ module ActsAsTenant
         scope
       end
     end
+
+    def tenant_change_hook=(hook)
+      raise(ArgumentError, "tenant_change_hook must be a Proc") unless hook.is_a?(Proc)
+      @tenant_change_hook = hook
+    end
+
   end
 end

--- a/lib/acts_as_tenant/configuration.rb
+++ b/lib/acts_as_tenant/configuration.rb
@@ -33,6 +33,5 @@ module ActsAsTenant
       raise(ArgumentError, "tenant_change_hook must be a Proc") unless hook.is_a?(Proc)
       @tenant_change_hook = hook
     end
-
   end
 end

--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -87,6 +87,5 @@ describe ActsAsTenant::Configuration do
 
       expect(truthy).to eq(true)
     end
-
   end
 end

--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -59,5 +59,34 @@ describe ActsAsTenant::Configuration do
 
       expect(ActsAsTenant.should_require_tenant?).to eq(false)
     end
+
+    it "runs a hook on current_tenant" do
+      truthy = false
+      ActsAsTenant.configure do |config|
+        config.tenant_change_hook = lambda do |tenant|
+          truthy = true
+        end
+      end
+
+      ActsAsTenant.current_tenant = "foobar"
+
+      expect(truthy).to eq(true)
+    end
+
+    it "runs a hook on with_tenant" do
+      truthy = false
+      ActsAsTenant.configure do |config|
+        config.tenant_change_hook = lambda do |tenant|
+          truthy = true
+        end
+      end
+
+      ActsAsTenant.with_tenant("foobar") do
+        # do nothing
+      end
+
+      expect(truthy).to eq(true)
+    end
+
   end
 end


### PR DESCRIPTION
I've been looking to use ActsAsTenant in addition to Postgres's row-level security (RLS).  With RLS, you can use a session variable to restrict the scope of queries to a single variable for a user.  Then, the user would not be able to query all rows from a single query. In an attempt to keep ActsAsTenant as simple as possible, I think the best way to do this is a `tenant_change_hook` (or a similar pattern). This would allow a user to run a block of code each time the tenant is changed.

Using this `tenant_change_hook`, you could implement RLS with the following code block:

```
ActsAsTenant.configure do |config|
  config.tenant_change_hook = lambda do |tenant|
    if tenant.present?
      ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql_array(["SET rls.account_id = ?;", tenant.id]))
      Rails.logger.info "Changed tenant to " + [tenant.id, tenant.name].to_json
    end
  end
end
```

I've been around open source projects. Be harsh ;) 
