### PR TITLE
Fix bleeding test_tenant into current_tenant

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -115,7 +115,7 @@ module ActsAsTenant
       raise ArgumentError, "block required"
     end
 
-    old_tenant = current_tenant
+    old_tenant = Current.current_tenant
     self.current_tenant = tenant
     value = block.call
     value
@@ -128,7 +128,7 @@ module ActsAsTenant
       raise ArgumentError, "block required"
     end
 
-    old_tenant = current_tenant
+    old_tenant = Current.current_tenant
     old_test_tenant = test_tenant
     old_unscoped = unscoped
 

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -364,6 +364,16 @@ describe ActsAsTenant do
     it "should raise an error when no block is provided" do
       expect { ActsAsTenant.with_tenant(nil) }.to raise_error(ArgumentError, /block required/)
     end
+
+    it "does not bleed test_tenant into current_tenant" do
+      ActsAsTenant.current_tenant = nil
+      ActsAsTenant.test_tenant = account
+
+      ActsAsTenant.with_tenant(accounts(:bar)) {}
+
+      ActsAsTenant.test_tenant = nil
+      expect(ActsAsTenant.current_tenant).to eq(nil)
+    end
   end
 
   describe "::without_tenant" do
@@ -410,6 +420,16 @@ describe ActsAsTenant do
       ActsAsTenant.test_tenant = account
       ActsAsTenant.without_tenant {}
       expect(ActsAsTenant.test_tenant).to eq(account)
+    end
+
+    it "does not bleed test_tenant into current_tenant" do
+      ActsAsTenant.current_tenant = nil
+      ActsAsTenant.test_tenant = account
+
+      ActsAsTenant.without_tenant {}
+
+      ActsAsTenant.test_tenant = nil
+      expect(ActsAsTenant.current_tenant).to eq(nil)
     end
 
     it "should return the value of the block" do


### PR DESCRIPTION
`with_tenant` and `without_tenant` blocks bleed `test_tenant` into `current_tenant`. This pr fixes it.

I already submitted a pr for this two years ago #278 but it didn't raise much interest and got stale.