### PR TITLE
tenantable_belongs_to method

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ Project.tasks.all #  => all tasks with account_id => 3
 
 Acts_as_tenant uses Rails' `default_scope` method to scope models. Rails 3.1 changed the way `default_scope` works in a good way. A user defined `default_scope` should integrate seamlessly with the one added by `acts_as_tenant`.
 
+### Validating belongs_to associations
+
+If you need to validate that a belongs_to association must have the same tenant as the model is defining the association. You can do so by using:
+
+```ruby
+tenantable_belongs_to :association_name
+```
+All options available to Rails' own `belongs_to` are also available to this method.
+
 ### Validating attribute uniqueness
 
 If you need to validate for uniqueness, chances are that you want to scope this validation to a tenant. You can do so by using:

--- a/spec/dummy/app/models/tenantable_task.rb
+++ b/spec/dummy/app/models/tenantable_task.rb
@@ -1,0 +1,8 @@
+class TenantableTask < ActiveRecord::Base
+  acts_as_tenant :account
+
+  tenantable_belongs_to :project
+  default_scope -> { where(completed: nil).order("name") }
+
+  validates_uniqueness_of :name
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -39,6 +39,13 @@ ActiveRecord::Schema.define(version: 1) do
     t.column :completed, :boolean
   end
 
+  create_table :tenantable_tasks, force: true do |t|
+    t.column :name, :string
+    t.column :account_id, :integer
+    t.column :project_id, :integer
+    t.column :completed, :boolean
+  end
+
   create_table :countries, force: true do |t|
     t.column :name, :string
   end

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -505,4 +505,31 @@ describe ActsAsTenant do
       expect(ActsAsTenant.current_tenant).to eq(accounts(:bar))
     end
   end
+
+  describe 'tenantable_belongs_to' do
+    let(:account) { accounts(:foo) }
+    let(:other_account) { accounts(:bar) }
+
+    it "validates that the task's account_id matches the project's account_id when tenantable_belongs_to is defined" do
+      project = Project.create!(account: account)
+      task = TenantableTask.new(project: project, account: account)
+
+      expect(task).to be_valid
+    end
+
+    it "is invalid if task's tenant_id does not match the project's tenant_id when tenantable_belongs_to is defined" do
+      project = Project.create!(account: account)
+      task = TenantableTask.new(project: project, account: other_account)
+
+      expect(task).not_to be_valid
+      expect(task.errors[:account_id]).to include("must match the project model's account_id")
+    end
+
+    it 'does not enforce tenant_id matching if default belongs_to is used' do
+      project = Project.create!(account: account)
+      task = Task.new(project: project, account: other_account)
+
+      expect(task).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Add a tenantable_belongs_to class method that automatically validates that the parent association must has the same tenant than the record is defining the tenantable_belongs_to association.