### PR TITLE
Require MFA on release

### DIFF
--- a/acts_as_tenant.gemspec
+++ b/acts_as_tenant.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/ErwinM/acts_as_tenant"
   spec.summary = "Add multi-tenancy to Rails applications using a shared db strategy"
   spec.description = "Integrates multi-tenancy into a Rails application in a convenient and out-of-your way manner"
+  spec.metadata = { "rubygems_mfa_required" => "true" }
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
### What is changing in this PR?
This PR adds the requirement to publish the gem with MFA enforcement for all owners. This requirement is recommended for all owners because it would help prevent unintentional releases of the gem long-term.

Per: [RubyGems doc](https://guides.rubygems.org/mfa-requirement-opt-in/)

