### PR TITLE
readme: used to_prepare instead of to_complete for tenant reset on console reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,23 +278,13 @@ end
 When using `config.require_tenant` alongside the `rails console`, a nice quality of life tweak is to set the tenant in the console session in your initializer script. For example in `config/initializers/acts_as_tenant.rb`:
 
 ```ruby
-SET_TENANT_PROC = lambda do
-  if defined?(Rails::Console)
-    puts "> ActsAsTenant.current_tenant = Account.first"
-    ActsAsTenant.current_tenant = Account.first
-  end
-end
-
 Rails.application.configure do
-  if Rails.env.development?
-    # Set the tenant to the first account in development on load
-    config.after_initialize do
-      SET_TENANT_PROC.call
-    end
-
-    # Reset the tenant after calling 'reload!' in the console
-    ActiveSupport::Reloader.to_complete do
-      SET_TENANT_PROC.call
+  if Rails.env.development? && defined?(Rails::Console)
+    # set the current_tenant during console startup and after calling reload!
+    # note: reload! calls the to_prepare callback twice
+    ActiveSupport::Reloader.to_prepare do
+      puts ">>> Setting ActsAsTenant.current_tenant = Account.first"
+      ActsAsTenant.current_tenant = Account.first
     end
   end
 end


### PR DESCRIPTION
**Issue Description:** 
The [QoL tip](https://github.com/ErwinM/acts_as_tenant/issues/344) in the configuration option specifies the use of `to_complete` reloader callback to set `ActsAsTenant.current_tenant` which works fine during the console startup but does not reset the tenant on console reload.

Also referenced in [this issue](https://github.com/ErwinM/acts_as_tenant/issues/344).

**Proposed fix:**
`to_complete` does not seem to work well in a console environment and thus, replacing it with `to_prepare` resets the tenant correctly, although the callback runs twice on console reload!