### PR TITLE
Pass ar_relation to `should_require_tenant?` for improved control

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,18 @@ ActsAsTenant.configure do |config|
 end
 ```
 
+The lambda can also optionally receive the ar_relation currently being evaulated as an argument. This is useful for finer control over tenant requirements.
+
+For example, if you wanted to require the tenant for every model except `User`, you could do the following:
+
+```ruby
+ActsAsTenant.configure do |config|
+  config.require_tenant = lambda do |relation|
+    relation.klass.name != "User"
+  end
+end
+```
+
 `ActsAsTenant.should_require_tenant?` is used to determine if a tenant is required in the current context, either by evaluating the lambda provided, or by returning the boolean value assigned to `config.require_tenant`.
 
 When using `config.require_tenant` alongside the `rails console`, a nice quality of life tweak is to set the tenant in the console session in your initializer script. For example in `config/initializers/acts_as_tenant.rb`:

--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -150,12 +150,11 @@ module ActsAsTenant
     ActsAsTenant.mutable_tenant!(false)
   end
 
-  def self.should_require_tenant?
-    if configuration.require_tenant.respond_to?(:call)
-      !!configuration.require_tenant.call
-    else
-      !!configuration.require_tenant
-    end
+  def self.should_require_tenant?(context = nil)
+    config = configuration.require_tenant
+    return !!config unless config.respond_to?(:call)
+
+    config.arity.zero? ? !!config.call : !!config.call(context)
   end
 end
 

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -17,7 +17,7 @@ module ActsAsTenant
         belongs_to tenant, scope, **valid_options
 
         default_scope lambda {
-          if ActsAsTenant.should_require_tenant? && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+          if ActsAsTenant.should_require_tenant?(self) && ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
             raise ActsAsTenant::Errors::NoTenantSet
           end
 

--- a/spec/acts_as_tenant/configuration_spec.rb
+++ b/spec/acts_as_tenant/configuration_spec.rb
@@ -30,6 +30,21 @@ describe ActsAsTenant::Configuration do
       expect(ActsAsTenant.should_require_tenant?).to eq(false)
     end
 
+    it "evaluates lambda with context" do
+      account = accounts(:foo)
+      test_context = nil
+
+      ActsAsTenant.configure do |config|
+        config.require_tenant = ->(context) {
+          test_context = context
+          context.klass.name == "Project"
+        }
+      end
+
+      expect { account.projects.create!(name: "foobar") }.to raise_error(ActsAsTenant::Errors::NoTenantSet)
+      expect(test_context.klass.name).to eq("Project")
+    end
+
     it "evaluates boolean" do
       ActsAsTenant.configure do |config|
         config.require_tenant = true


### PR DESCRIPTION
Enhance the `should_require_tenant?` method to accept a context parameter, allowing for more granular control over tenant requirements. 

This change maintains backward compatibility while enabling the evaluation of conditions based on the provided ar_relation object.